### PR TITLE
feat: Add route to find an event by it's transaction id

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ event = Event(
 client.events().create(event)
 ```
 
+``` python
+transaction_id = "6afadc2a-f28c-40a4-a868-35636f229765"
+event = client.events().find(transaction_id)
+```
+
 ### Customers
 [Api reference](https://doc.getlago.com/docs/api/customers/customer-object)
 

--- a/lago_python_client/clients/base_client.py
+++ b/lago_python_client/clients/base_client.py
@@ -15,7 +15,7 @@ class BaseClient:
         self.base_url = base_url
         self.api_key = api_key
 
-    def find(self, resource_id: str, params: Dict):
+    def find(self, resource_id: str, params: Dict=None):
         api_resource = self.api_resource() + '/' + resource_id
         query_url = urljoin(self.base_url, api_resource)
 

--- a/lago_python_client/clients/base_client.py
+++ b/lago_python_client/clients/base_client.py
@@ -15,6 +15,19 @@ class BaseClient:
         self.base_url = base_url
         self.api_key = api_key
 
+    def find(self, resource_id: str, params: Dict):
+        api_resource = self.api_resource() + '/' + resource_id
+        query_url = urljoin(self.base_url, api_resource)
+
+        data=None
+        if params is not None:
+            data = json.dumps(params)
+
+        api_response = requests.get(query_url, data=data, headers=self.headers())
+        data = self.handle_response(api_response).json().get(self.root_name())
+
+        return self.prepare_response(data)
+
     def create(self, input_object: BaseModel):
         query_url = urljoin(self.base_url, self.api_resource())
         query_parameters = {

--- a/lago_python_client/clients/event_client.py
+++ b/lago_python_client/clients/event_client.py
@@ -1,4 +1,6 @@
 from .base_client import BaseClient
+from lago_python_client.models.event import EventResponse
+from typing import Dict
 
 
 class EventClient(BaseClient):
@@ -7,3 +9,6 @@ class EventClient(BaseClient):
 
     def root_name(self):
         return 'event'
+
+    def prepare_response(self, data: Dict):
+        return EventResponse.parse_obj(data)

--- a/lago_python_client/models/event.py
+++ b/lago_python_client/models/event.py
@@ -8,3 +8,12 @@ class Event(BaseModel):
     code: str
     timestamp: Optional[int]
     properties: Optional[dict]
+
+class EventResponse(BaseModel):
+    lago_id: str
+    transaction_id: str
+    customer_id: str
+    code: str
+    timestamp: str
+    properties: Optional[dict]
+    created_at: str

--- a/tests/fixtures/event.json
+++ b/tests/fixtures/event.json
@@ -1,0 +1,13 @@
+{
+  "event": {
+    "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "transaction_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+    "customer_id": "24691b9a-7330-409d-9dfd-d80582593297",
+    "code": "test",
+    "timestamp": "2022-04-29T08:59:51Z",
+    "properties": {
+      "custom_field": "custom"
+    },
+    "created_at": "2022-04-29T08:59:51Z"
+  }
+}

--- a/tests/test_event_client.py
+++ b/tests/test_event_client.py
@@ -42,7 +42,7 @@ class TestEventClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri('GET', 'https://api.getlago.com/api/v1/events/' + event_id, text=mock_response())
-            response = client.events().find(event_id, None)
+            response = client.events().find(event_id)
 
         self.assertEqual(response.lago_id, event_id)
 
@@ -55,7 +55,7 @@ class TestEventClient(unittest.TestCase):
             m.register_uri('GET', 'https://api.getlago.com/api/v1/events/' + event_id, status_code=404, text='')
 
             with self.assertRaises(LagoApiError):
-                client.events().find(event_id, None)
+                client.events().find(event_id)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_event_client.py
+++ b/tests/test_event_client.py
@@ -1,5 +1,6 @@
 import unittest
 import requests_mock
+import os
 
 from lago_python_client.client import Client
 from lago_python_client.models import Event
@@ -9,6 +10,12 @@ from lago_python_client.clients.base_client import LagoApiError
 def create_event():
     return Event(customer_id='5eb02857-a71e-4ea2-bcf9-57d8885990ba', code='123', transaction_id='123')
 
+def mock_response():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(this_dir, 'fixtures/event.json')
+
+    with open(data_path, 'r') as event_response:
+        return event_response.read()
 
 class TestEventClient(unittest.TestCase):
     def test_valid_create_events_request(self):
@@ -29,6 +36,26 @@ class TestEventClient(unittest.TestCase):
             with self.assertRaises(LagoApiError):
                 client.events().create(create_event())
 
+    def test_valid_find_event_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+        event_id = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/events/' + event_id, text=mock_response())
+            response = client.events().find(event_id, None)
+
+        self.assertEqual(response.lago_id, event_id)
+
+    def test_invalid_find_events_request(self):
+        client = Client(api_key='invalid')
+        event_id = 'INVALID_EVENT'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('POST', 'https://api.getlago.com/api/v1/events', status_code=401, text='')
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/events/' + event_id, status_code=404, text='')
+
+            with self.assertRaises(LagoApiError):
+                client.events().find(event_id, None)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Following recent introduction of the event `find` route on lago api (https://github.com/getlago/lago-api/pull/269), this PR aims to replicate the update of the ruby client (https://github.com/getlago/lago-ruby-client/pull/16)