### PR TITLE
feat: synchronous stripe customer creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ customer = Customer(
     zipcode=None,
     billing_configuration=BillingConfiguration(
       payment_provider=None,
-      provider_customer_id=None
+      provider_customer_id=None,
+      sync=None
     )
 )
 client.customers().create(customer)

--- a/lago_python_client/models/customer.py
+++ b/lago_python_client/models/customer.py
@@ -4,6 +4,7 @@ from typing import Optional
 class BillingConfiguration(BaseModel):
     payment_provider: Optional[str]
     provider_customer_id: Optional[str]
+    sync: Optional[bool]
 
 class Customer(BaseModel):
     customer_id: str


### PR DESCRIPTION
Add a new sync flag in customer[billing_configuration] in order to allow synchronous creation of the stripe customer. It will return the stripe customer ID immediately rather by waiting for the webhook