### PR TITLE
feat: Add new customer current usage route

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ customer = Customer(
 client.customers().create(customer)
 ```
 
+```python
+customer_usage = client.customers().current_usage('customer_id')
+```
+
 ### Invoices
 [Api reference](https://doc.getlago.com/docs/api/invoices/invoice-object)
 

--- a/lago_python_client/clients/customer_client.py
+++ b/lago_python_client/clients/customer_client.py
@@ -1,6 +1,10 @@
+import requests
+
 from .base_client import BaseClient
 from lago_python_client.models.customer import CustomerResponse
+from lago_python_client.models.customer_usage import CustomerUsageResponse
 from typing import Dict
+from urllib.parse import urljoin
 
 
 class CustomerClient(BaseClient):
@@ -12,3 +16,12 @@ class CustomerClient(BaseClient):
 
     def prepare_response(self, data: Dict):
         return CustomerResponse.parse_obj(data)
+
+    def current_usage(self, resource_id: str):
+        api_resource = self.api_resource() + '/' + resource_id + '/current_usage'
+        query_url = urljoin(self.base_url, api_resource)
+
+        api_response = requests.get(query_url, headers=self.headers())
+        data = self.handle_response(api_response).json().get('customer_usage')
+
+        return CustomerUsageResponse.parse_obj(data)

--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -4,3 +4,4 @@ from lago_python_client.models.event import Event
 from lago_python_client.models.customer import Customer, BillingConfiguration
 from lago_python_client.models.invoice import InvoiceStatusChange
 from lago_python_client.models.subscription import Subscription
+from lago_python_client.models.customer_usage import BillableMetric, Charge, ChargeUsage, CustomerUsageResponse

--- a/lago_python_client/models/customer_usage.py
+++ b/lago_python_client/models/customer_usage.py
@@ -1,0 +1,31 @@
+from typing import List
+from pydantic import BaseModel, Field
+
+class BillableMetric(BaseModel):
+  lago_id: str
+  name: str
+  code: str
+  aggregation_type: str
+
+class Charge(BaseModel):
+  lago_id: str
+  charge_model: str
+
+class ChargeUsage(BaseModel):
+  units: float
+  amount_cents: int
+  amount_currency: str
+  charge: Charge
+  billable_metric: BillableMetric
+
+class CustomerUsageResponse(BaseModel):
+  from_date: str
+  to_date: str
+  issuing_date: str
+  amount_cents: int
+  amount_currency: str
+  total_amount_cents: int
+  total_amount_currency: str
+  vat_amount_cents: int
+  vat_amount_currency: str
+  charges_usage: List[ChargeUsage]

--- a/tests/fixtures/customer_usage.json
+++ b/tests/fixtures/customer_usage.json
@@ -1,0 +1,30 @@
+{
+  "customer_usage": {
+    "from_date": "2022-07-01",
+    "to_date": "2022-07-31",
+    "issuing_date": "2022-08-01",
+    "amount_cents": 123,
+    "amount_currency": "EUR",
+    "total_amount_cents": 123,
+    "total_amount_currency": "EUR",
+    "vat_amount_cents": 0,
+    "vat_amount_currency": "EUR",
+    "charges_usage": [
+      {
+        "units": "1.0",
+        "amount_cents": 123,
+        "amount_currency": "EUR",
+        "charge": {
+          "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+          "charge_model": "graduated"
+        },
+        "billable_metric": {
+          "lago_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
+          "name": "Usage metric",
+          "code": "usage_metric",
+          "aggregation_type": "sum"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add new `GET /api/v1/customers/:customer_id/current_usage` route

Related to:
- https://github.com/getlago/lago-api/pull/322
- https://github.com/getlago/lago-docs/pull/15