### PR TITLE
fix: plan with graduated charge type

### DIFF
--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -1,18 +1,15 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List
-
+from typing import Optional, List, Union
 
 class Charge(BaseModel):
     id: Optional[str]
     billable_metric_id: Optional[str]
     amount_currency: Optional[str]
     charge_model: Optional[str]
-    properties: Optional[dict]
-
+    properties: Optional[Union[dict, list]]
 
 class Charges(BaseModel):
     __root__: List[Charge]
-
 
 class Plan(BaseModel):
     name: Optional[str]

--- a/lago_python_client/version.py
+++ b/lago_python_client/version.py
@@ -1,1 +1,1 @@
-LAGO_VERSION = '0.3.0'
+LAGO_VERSION = '0.3.1'

--- a/tests/fixtures/graduated_plan.json
+++ b/tests/fixtures/graduated_plan.json
@@ -1,0 +1,38 @@
+{
+  "plan": {
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "name": "test1",
+    "created_at": "2022-07-01T14:47:14Z",
+    "code": "plan_code",
+    "interval": "weekly",
+    "description": "hello_this_is_desc333",
+    "amount_cents": 900,
+    "amount_currency": "EUR",
+    "trial_period": 3.0,
+    "pay_in_advance": true,
+    "bill_charges_monthly": null,
+    "charges": [
+      {
+        "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
+        "lago_billable_metric_id": "a6947936-628f-4945-8857-db6858ee7941",
+        "created_at": "2022-07-01T14:47:14Z",
+        "amount_currency": "EUR",
+        "charge_model": "standard",
+        "properties": [
+          {
+              "to_value": 1,
+              "from_value": 0,
+              "flat_amount": "0",
+              "per_unit_amount": "0"
+          },
+          {
+              "to_value": null,
+              "from_value": 2,
+              "flat_amount": "0",
+              "per_unit_amount": "3200"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -29,10 +29,49 @@ def plan_object():
         charges=charges
     )
 
+def graduated_plan_object():
+    charge = Charge(
+        billable_metric_id='id',
+        charge_model='graduated',
+        amount_currency='EUR',
+        properties = [
+            {
+                'to_value': 1,
+                'from_value': 0,
+                'flat_amount': "0",
+                'per_unit_amount': "0"
+            },
+            {
+                'to_value': None,
+                'from_value': 2,
+                'flat_amount': "0",
+                'per_unit_amount': "3200"
+            }
+        ]
+    )
+    charges = Charges(__root__=[charge])
+
+    return Plan(
+        name='name',
+        code='code_first',
+        amount_cents=1000,
+        amount_currency='EUR',
+        description='desc',
+        interval='weekly',
+        pay_in_advance=True,
+        charges = charges,
+    )
 
 def mock_response():
     this_dir = os.path.dirname(os.path.abspath(__file__))
     data_path = os.path.join(this_dir, 'fixtures/plan.json')
+
+    with open(data_path, 'r') as plan_response:
+        return plan_response.read()
+
+def mock_graduated_response():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(this_dir, 'fixtures/graduated_plan.json')
 
     with open(data_path, 'r') as plan_response:
         return plan_response.read()
@@ -54,6 +93,16 @@ class TestPlanClient(unittest.TestCase):
             m.register_uri('POST', 'https://api.getlago.com/api/v1/plans', text=mock_response())
             response = client.plans().create(plan_object())
 
+        self.assertEqual(response.lago_id, 'b7ab2926-1de8-4428-9bcd-779314ac129b')
+        self.assertEqual(response.code, 'plan_code')
+
+    def test_valid_create_graduated_plan_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('POST', 'https://api.getlago.com/api/v1/plans', text=mock_graduated_response())
+            response = client.plans().create(graduated_plan_object())
+        
         self.assertEqual(response.lago_id, 'b7ab2926-1de8-4428-9bcd-779314ac129b')
         self.assertEqual(response.code, 'plan_code')
 


### PR DESCRIPTION
** Context **

Plan Charge type is wrong when graduated or package, it generates validation error

** Changes ** 

Adapt the Plan Charge type to support either `dict` or `list`