### PR TITLE
misc: Use external_id instead of customer_id and subscription_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ event = Event(
 client.events().create(event)
 
 event = BatchEvent(
-    subscription_ids=[
+    external_subscription_ids=[
       "5eb02857-a71e-4ea2-bcf9-57d8885990ba", "8ztrg2857-a71e-4ea2-bcf9-57d8885990ba"],
     transaction_id="__UNIQUE_ID__",
     code="123",
@@ -130,7 +130,7 @@ from lago_python_client.models import Subscription
 subscription = Subscription(
     external_customer_id="5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     plan_code="code",
-    unique_id="12345",
+    external_id="12345",
     name="display name"
     billing_time="anniversary"
 )

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ client = Client(api_key = 'key')
 from lago_python_client.models import Event, BatchEvent
 
 event = Event(
-    customer_id="5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+    external_customer_id="5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     transaction_id="__UNIQUE_ID__",
     code="123",
     timestamp=1650893379,
@@ -58,7 +58,7 @@ event = client.events().find(transaction_id)
 from lago_python_client.models import Customer, BillingConfiguration
 
 customer = Customer(
-    customer_id="5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+    external_id="5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     address_line1=None,
     address_line2=None,
     city=None,
@@ -83,7 +83,7 @@ client.customers().create(customer)
 ```
 
 ```python
-customer_usage = client.customers().current_usage('customer_id', 'subscription_id')
+customer_usage = client.customers().current_usage('external_customer_id', 'subscription_id')
 ```
 
 ### Invoices
@@ -128,7 +128,7 @@ invoice = client.invoices().download('5eb02857-a71e-4ea2-bcf9-57d8885990ba')
 from lago_python_client.models import Subscription
 
 subscription = Subscription(
-    customer_id="5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+    external_customer_id="5eb02857-a71e-4ea2-bcf9-57d8885990ba",
     plan_code="code",
     unique_id="12345",
     name="display name"
@@ -143,7 +143,7 @@ client.subscriptions().update(update_params, 'id')
 
 client.subscriptions().destroy('id')
 
-client.subscriptions().find_all({'customer_id': '123'})
+client.subscriptions().find_all({'external_customer_id': '123'})
 ```
 
 ### Applied coupons
@@ -153,7 +153,7 @@ client.subscriptions().find_all({'customer_id': '123'})
 from lago_python_client.models import AppliedCoupon
 
 applied_coupon = AppliedCoupon(
-  customer_id="5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+  external_customer_id="5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
   coupon_code="code",
   amount_cents=123,
   amount_currency="EUR"
@@ -169,7 +169,7 @@ client.applied_coupons().create(applied_coupon)
 from lago_python_client.models import AppliedAddOn
 
 applied_add_on = AppliedAddOn(
-  customer_id="5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+  external_customer_id="5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
   add_on_code="code",
   amount_cents=123,
   amount_currency="EUR"

--- a/lago_python_client/clients/customer_client.py
+++ b/lago_python_client/clients/customer_client.py
@@ -17,8 +17,8 @@ class CustomerClient(BaseClient):
     def prepare_response(self, data: Dict):
         return CustomerResponse.parse_obj(data)
 
-    def current_usage(self, resource_id: str, subscription_id: str):
-        api_resource = self.api_resource() + '/' + resource_id + '/current_usage?subscription_id=' + subscription_id
+    def current_usage(self, resource_id: str, external_subscription_id: str):
+        api_resource = self.api_resource() + '/' + resource_id + '/current_usage?external_subscription_id=' + external_subscription_id
         query_url = urljoin(self.base_url, api_resource)
 
         api_response = requests.get(query_url, headers=self.headers())

--- a/lago_python_client/models/applied_add_on.py
+++ b/lago_python_client/models/applied_add_on.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 
 class AppliedAddOn(BaseModel):
-    customer_id: str
+    external_customer_id: str
     add_on_code: str
     amount_cents: Optional[int]
     amount_currency: Optional[str]
@@ -13,7 +13,7 @@ class AppliedAddOnResponse(BaseModel):
     lago_id: str
     lago_add_on_id: str
     add_on_code: str
-    customer_id: str
+    external_customer_id: str
     lago_customer_id: str
     amount_cents: int
     amount_currency: str

--- a/lago_python_client/models/applied_coupon.py
+++ b/lago_python_client/models/applied_coupon.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 
 class AppliedCoupon(BaseModel):
-    customer_id: str
+    external_customer_id: str
     coupon_code: str
     amount_cents: Optional[int]
     amount_currency: Optional[str]
@@ -13,7 +13,7 @@ class AppliedCouponResponse(BaseModel):
     lago_id: str
     lago_coupon_id: str
     coupon_code: str
-    customer_id: str
+    external_customer_id: str
     lago_customer_id: str
     amount_cents: int
     amount_currency: str

--- a/lago_python_client/models/customer.py
+++ b/lago_python_client/models/customer.py
@@ -9,7 +9,7 @@ class BillingConfiguration(BaseModel):
 
 
 class Customer(BaseModel):
-    customer_id: str
+    external_id: str
     address_line1: Optional[str]
     address_line2: Optional[str]
     city: Optional[str]
@@ -29,7 +29,7 @@ class Customer(BaseModel):
 
 class CustomerResponse(BaseModel):
     lago_id: str
-    customer_id: str
+    external_id: str
     address_line1: Optional[str]
     address_line2: Optional[str]
     city: Optional[str]

--- a/lago_python_client/models/event.py
+++ b/lago_python_client/models/event.py
@@ -4,7 +4,7 @@ from typing import Optional, List
 
 class Event(BaseModel):
     transaction_id: str
-    customer_id: Optional[str]
+    external_customer_id: Optional[str]
     subscription_id: Optional[str]
     code: str
     timestamp: Optional[int]
@@ -13,7 +13,7 @@ class Event(BaseModel):
 
 class BatchEvent(BaseModel):
     transaction_id: str
-    customer_id: Optional[str]
+    external_customer_id: Optional[str]
     subscription_ids: List[str]
     code: str
     timestamp: Optional[int]
@@ -23,7 +23,7 @@ class BatchEvent(BaseModel):
 class EventResponse(BaseModel):
     lago_id: str
     transaction_id: str
-    customer_id: Optional[str]
+    external_customer_id: Optional[str]
     lago_customer_id: Optional[str]
     lago_subscription_id: Optional[str]
     subscription_unique_id: Optional[str]

--- a/lago_python_client/models/event.py
+++ b/lago_python_client/models/event.py
@@ -5,7 +5,7 @@ from typing import Optional, List
 class Event(BaseModel):
     transaction_id: str
     external_customer_id: Optional[str]
-    subscription_id: Optional[str]
+    external_subscription_id: Optional[str]
     code: str
     timestamp: Optional[int]
     properties: Optional[dict]
@@ -14,7 +14,7 @@ class Event(BaseModel):
 class BatchEvent(BaseModel):
     transaction_id: str
     external_customer_id: Optional[str]
-    subscription_ids: List[str]
+    external_subscription_ids: List[str]
     code: str
     timestamp: Optional[int]
     properties: Optional[dict]
@@ -26,7 +26,7 @@ class EventResponse(BaseModel):
     external_customer_id: Optional[str]
     lago_customer_id: Optional[str]
     lago_subscription_id: Optional[str]
-    subscription_unique_id: Optional[str]
+    external_subscription_id: Optional[str]
     code: str
     timestamp: str
     properties: Optional[dict]

--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 class Subscription(BaseModel):
     plan_code: Optional[str]
-    customer_id: Optional[str]
+    external_customer_id: Optional[str]
     name: Optional[str]
     subscription_id: Optional[str]
     unique_id: Optional[str]
@@ -14,7 +14,7 @@ class Subscription(BaseModel):
 class SubscriptionResponse(BaseModel):
     lago_id: str
     lago_customer_id: Optional[str]
-    customer_id: Optional[str]
+    external_customer_id: Optional[str]
     canceled_at: Optional[str]
     created_at: Optional[str]
     plan_code: Optional[str]

--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -6,8 +6,7 @@ class Subscription(BaseModel):
     plan_code: Optional[str]
     external_customer_id: Optional[str]
     name: Optional[str]
-    subscription_id: Optional[str]
-    unique_id: Optional[str]
+    external_id: Optional[str]
     billing_time: Optional[str]
 
 
@@ -21,7 +20,7 @@ class SubscriptionResponse(BaseModel):
     started_at: Optional[str]
     status: Optional[str]
     name: Optional[str]
-    unique_id: Optional[str]
+    external_id: Optional[str]
     billing_time: Optional[str]
     terminated_at: Optional[str]
     subscription_date: Optional[str]

--- a/tests/fixtures/applied_add_on.json
+++ b/tests/fixtures/applied_add_on.json
@@ -3,7 +3,7 @@
     "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "lago_add_on_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "add_on_code": "b7ab2",
-    "customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
     "amount_cents": 123,
     "amount_currency": "EUR",

--- a/tests/fixtures/applied_coupon.json
+++ b/tests/fixtures/applied_coupon.json
@@ -3,7 +3,7 @@
     "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "lago_coupon_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "coupon_code": "code",
-    "customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
     "amount_cents": 123,
     "amount_currency": "EUR",

--- a/tests/fixtures/customer.json
+++ b/tests/fixtures/customer.json
@@ -1,7 +1,7 @@
 {
   "customer": {
     "lago_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
-    "customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "external_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "address_line1": "5230 Penfield Ave",
     "address_line2": null,
     "city": "Woodland Hills",

--- a/tests/fixtures/event.json
+++ b/tests/fixtures/event.json
@@ -2,7 +2,7 @@
   "event": {
     "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "transaction_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
-    "customer_id": "24691b9a-7330-409d-9dfd-d80582593297",
+    "external_customer_id": "24691b9a-7330-409d-9dfd-d80582593297",
     "code": "test",
     "timestamp": "2022-04-29T08:59:51Z",
     "properties": {

--- a/tests/fixtures/subscription.json
+++ b/tests/fixtures/subscription.json
@@ -2,7 +2,7 @@
   "subscription": {
     "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
-    "customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "canceled_at": "2022-04-29T08:59:51Z",
     "created_at": "2022-04-29T08:59:51Z",
     "plan_code": "eartha lynch",

--- a/tests/fixtures/subscription_index.json
+++ b/tests/fixtures/subscription_index.json
@@ -3,7 +3,7 @@
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
       "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
-      "customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+      "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
       "canceled_at": "2022-04-29T08:59:51Z",
       "created_at": "2022-04-29T08:59:51Z",
       "plan_code": "eartha lynch",

--- a/tests/test_applied_add_on_client.py
+++ b/tests/test_applied_add_on_client.py
@@ -9,7 +9,7 @@ from lago_python_client.clients.base_client import LagoApiError
 
 def create_applied_add_on():
     return AppliedAddOn(
-        customer_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba',
+        external_customer_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba',
         add_on_code='Free-Lemon-Juice'
     )
 
@@ -30,7 +30,7 @@ class TestAppliedAddOnClient(unittest.TestCase):
             m.register_uri('POST', 'https://api.getlago.com/api/v1/applied_add_ons', text=mock_response())
             response = client.applied_add_ons().create(create_applied_add_on())
 
-        self.assertEqual(response.customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+        self.assertEqual(response.external_customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
     def test_invalid_create_applied_add_on_request(self):
         client = Client(api_key='invalid')

--- a/tests/test_applied_coupon_client.py
+++ b/tests/test_applied_coupon_client.py
@@ -9,7 +9,7 @@ from lago_python_client.clients.base_client import LagoApiError
 
 def create_applied_coupon():
     return AppliedCoupon(
-        customer_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba',
+        external_customer_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba',
         coupon_code='Free-Lemon-Juice'
     )
 
@@ -30,7 +30,7 @@ class TestAppliedCouponClient(unittest.TestCase):
             m.register_uri('POST', 'https://api.getlago.com/api/v1/applied_coupons', text=mock_response())
             response = client.applied_coupons().create(create_applied_coupon())
 
-        self.assertEqual(response.customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+        self.assertEqual(response.external_customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
     def test_invalid_create_applied_coupon_request(self):
         client = Client(api_key='invalid')

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -53,7 +53,7 @@ class TestCustomerClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri('GET',
-                           'https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?subscription_id=123',
+                           'https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123',
                            text=mock_response('customer_usage'))
             response = client.customers().current_usage('external_customer_id', '123')
 
@@ -66,7 +66,7 @@ class TestCustomerClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri('GET',
-                           'https://api.getlago.com/api/v1/customers/invalid_customer/current_usage?subscription_id=123',
+                           'https://api.getlago.com/api/v1/customers/invalid_customer/current_usage?external_subscription_id=123',
                            status_code=404, text='')
 
             with self.assertRaises(LagoApiError):

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -9,7 +9,7 @@ from lago_python_client.clients.base_client import LagoApiError
 
 def create_customer():
     return Customer(
-        customer_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba',
+        external_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba',
         name='Gavin Belson',
         billing_configuration=BillingConfiguration(
             payment_provider='stripe',
@@ -32,7 +32,7 @@ class TestCustomerClient(unittest.TestCase):
             m.register_uri('POST', 'https://api.getlago.com/api/v1/customers', text=mock_response())
             response = client.customers().create(create_customer())
 
-        self.assertEqual(response.customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+        self.assertEqual(response.external_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
         self.assertEqual(response.name, 'Gavin Belson')
         self.assertEqual(response.email, 'dinesh@piedpiper.test')
         self.assertEqual(response.billing_configuration.payment_provider, 'stripe')
@@ -53,9 +53,9 @@ class TestCustomerClient(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             m.register_uri('GET',
-                           'https://api.getlago.com/api/v1/customers/customer_id/current_usage?subscription_id=123',
+                           'https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?subscription_id=123',
                            text=mock_response('customer_usage'))
-            response = client.customers().current_usage('customer_id', '123')
+            response = client.customers().current_usage('external_customer_id', '123')
 
         self.assertEqual(response.from_date, '2022-07-01')
         self.assertEqual(len(response.charges_usage), 1)

--- a/tests/test_event_client.py
+++ b/tests/test_event_client.py
@@ -9,7 +9,7 @@ from lago_python_client.clients.base_client import LagoApiError
 
 
 def create_event():
-    return Event(customer_id='5eb02857-a71e-4ea2-bcf9-57d8885990ba', code='123', transaction_id='123')
+    return Event(external_customer_id='5eb02857-a71e-4ea2-bcf9-57d8885990ba', code='123', transaction_id='123')
 
 def create_batch_event():
     return BatchEvent(subscription_ids=['88u02857-a71e-4ea2-bcf9-57d8885990ba'], code='123', transaction_id='123')

--- a/tests/test_event_client.py
+++ b/tests/test_event_client.py
@@ -12,7 +12,7 @@ def create_event():
     return Event(external_customer_id='5eb02857-a71e-4ea2-bcf9-57d8885990ba', code='123', transaction_id='123')
 
 def create_batch_event():
-    return BatchEvent(subscription_ids=['88u02857-a71e-4ea2-bcf9-57d8885990ba'], code='123', transaction_id='123')
+    return BatchEvent(external_subscription_ids=['88u02857-a71e-4ea2-bcf9-57d8885990ba'], code='123', transaction_id='123')
 
 def mock_response():
     this_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -9,7 +9,7 @@ from lago_python_client.clients.base_client import LagoApiError
 
 def create_subscription():
     return Subscription(external_customer_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba', plan_code='eartha lynch',
-                        unique_id='code', billing_time='anniversary')
+                        external_id='code', billing_time='anniversary')
 
 
 def mock_response():

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -8,7 +8,7 @@ from lago_python_client.clients.base_client import LagoApiError
 
 
 def create_subscription():
-    return Subscription(customer_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba', plan_code='eartha lynch',
+    return Subscription(external_customer_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba', plan_code='eartha lynch',
                         unique_id='code', billing_time='anniversary')
 
 
@@ -36,7 +36,7 @@ class TestSubscriptionClient(unittest.TestCase):
             m.register_uri('POST', 'https://api.getlago.com/api/v1/subscriptions', text=mock_response())
             response = client.subscriptions().create(create_subscription())
 
-        self.assertEqual(response.customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+        self.assertEqual(response.external_customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
         self.assertEqual(response.status, 'active')
         self.assertEqual(response.plan_code, 'eartha lynch')
         self.assertEqual(response.billing_time, 'anniversary')
@@ -60,7 +60,7 @@ class TestSubscriptionClient(unittest.TestCase):
                            text=mock_response())
             response = client.subscriptions().update(Subscription(name='name'), identifier)
 
-        self.assertEqual(response.customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+        self.assertEqual(response.external_customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
         self.assertEqual(response.status, 'active')
         self.assertEqual(response.plan_code, 'eartha lynch')
         self.assertEqual(response.billing_time, 'anniversary')
@@ -86,7 +86,7 @@ class TestSubscriptionClient(unittest.TestCase):
             m.register_uri('DELETE', 'https://api.getlago.com/api/v1/subscriptions/' + identifier, text=mock_response())
             response = client.subscriptions().destroy(identifier)
 
-        self.assertEqual(response.customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+        self.assertEqual(response.external_customer_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
         self.assertEqual(response.status, 'active')
         self.assertEqual(response.plan_code, 'eartha lynch')
 
@@ -105,9 +105,9 @@ class TestSubscriptionClient(unittest.TestCase):
         client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
         with requests_mock.Mocker() as m:
-            m.register_uri('GET', 'https://api.getlago.com/api/v1/subscriptions?customer_id=123',
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/subscriptions?external_customer_id=123',
                            text=mock_collection_response())
-            response = client.subscriptions().find_all({'customer_id': '123'})
+            response = client.subscriptions().find_all({'external_customer_id': '123'})
 
         self.assertEqual(response['subscriptions'][0].lago_id, 'b7ab2926-1de8-4428-9bcd-779314ac129b')
         self.assertEqual(response['meta']['current_page'], 1)


### PR DESCRIPTION
## Context

We want to clarify the difference between lago ids and external ids.

Today, we have `customer_id` on customers and `subscription_id|unique_id` on subscriptions.

On the API, the goal is to use external_ids:
- `external_id` or `external_customer_id` for customer
- `external_id` or `external_subscription_id` for subscription

## Description

The goal of this PR is to:
- rename `customer_id` to `external_id` on customers
- rename `subscription_id` to `external_id` on subscriptions
- remove `unique_id` from subscriptions
