### PR TITLE
feat: Add previous and next attributes on Subscription

### DIFF
--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -24,3 +24,6 @@ class SubscriptionResponse(BaseModel):
     billing_time: Optional[str]
     terminated_at: Optional[str]
     subscription_date: Optional[str]
+    previous_plan_code: Optional[str]
+    next_plan_code: Optional[str]
+    downgrade_plan_date: Optional[str]

--- a/tests/fixtures/subscription.json
+++ b/tests/fixtures/subscription.json
@@ -10,6 +10,9 @@
     "status": "active",
     "billing_time": "anniversary",
     "terminated_at": null,
-    "subscription_date": "2022-04-29"
+    "subscription_date": "2022-04-29",
+    "previous_plan_code": null,
+    "next_plan_code": null,
+    "downgrade_plan_date": null
   }
 }


### PR DESCRIPTION
This PR is adding support for the following attributes on Subscription:
- `previous_plan_code`
- `next_plan_code`
- `downgrade_plan_date`