### PR TITLE
feat(credit_notes): Add Credit note API client

### DIFF
--- a/lago_python_client/client.py
+++ b/lago_python_client/client.py
@@ -3,6 +3,7 @@ from lago_python_client.clients.applied_coupon_client import AppliedCouponClient
 from lago_python_client.clients.billable_metric_client import BillableMetricClient
 from lago_python_client.clients.coupon_client import CouponClient
 from lago_python_client.clients.group_client import GroupClient
+from lago_python_client.clients.credit_note_client import CreditNoteClient
 from lago_python_client.clients.plan_client import PlanClient
 from lago_python_client.clients.add_on_client import AddOnClient
 from lago_python_client.clients.organization_client import OrganizationClient
@@ -38,6 +39,9 @@ class Client:
 
     def subscriptions(self):
         return SubscriptionClient(self.base_api_url(), self.api_key)
+
+    def credit_notes(self):
+        return CreditNoteClient(self.base_api_url(), self.api_key)
 
     def customers(self):
         return CustomerClient(self.base_api_url(), self.api_key)

--- a/lago_python_client/clients/__init__.py
+++ b/lago_python_client/clients/__init__.py
@@ -2,6 +2,7 @@ from lago_python_client.clients.applied_add_on_client import AppliedAddOnClient
 from lago_python_client.clients.applied_coupon_client import AppliedCouponClient
 from lago_python_client.clients.billable_metric_client import BillableMetricClient
 from lago_python_client.clients.coupon_client import CouponClient
+from lago_python_client.clients.credit_note_client import CreditNoteClient
 from lago_python_client.clients.plan_client import PlanClient
 from lago_python_client.clients.add_on_client import AddOnClient
 from lago_python_client.clients.organization_client import OrganizationClient

--- a/lago_python_client/clients/credit_note_client.py
+++ b/lago_python_client/clients/credit_note_client.py
@@ -1,0 +1,33 @@
+import requests
+
+from .base_client import BaseClient
+from lago_python_client.models.credit_note import CreditNoteResponse
+from typing import Dict
+from urllib.parse import urljoin
+from requests import Response
+
+class CreditNoteClient(BaseClient):
+    def api_resource(self):
+        return 'credit_notes'
+
+    def root_name(self):
+        return 'credit_note'
+
+    def prepare_response(self, data: Dict):
+        return CreditNoteResponse.parse_obj(data)
+
+    def download(self, resource_id: str):
+        api_resource = self.api_resource() + '/' + resource_id + '/download'
+        query_url = urljoin(self.base_url, api_resource)
+        api_response = requests.post(query_url, headers=self.headers())
+        data = self.handle_response(api_response).json().get(self.root_name())
+
+        return self.prepare_response(data)
+
+    def void(self, resource_id: str):
+        api_resource = self.api_resource() + '/' + resource_id + '/void'
+        query_url = urljoin(self.base_url, api_resource)
+        api_response = requests.put(query_url, headers=self.headers())
+        data = self.handle_response(api_response).json().get(self.root_name())
+
+        return self.prepare_response(data)

--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -2,6 +2,7 @@ from lago_python_client.models.applied_add_on import AppliedAddOn
 from lago_python_client.models.applied_coupon import AppliedCoupon
 from lago_python_client.models.billable_metric import BillableMetric, BillableMetricGroup
 from lago_python_client.models.coupon import Coupon
+from lago_python_client.models.credit_note import Item, Items, CreditNote, CreditNoteUpdate
 from lago_python_client.models.plan import Plan, Charges, Charge
 from lago_python_client.models.add_on import AddOn
 from lago_python_client.models.organization import Organization, OrganizationBillingConfiguration

--- a/lago_python_client/models/credit_note.py
+++ b/lago_python_client/models/credit_note.py
@@ -1,0 +1,55 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from .invoice import FeeResponse
+
+class ItemResponse(BaseModel):
+    lago_id: Optional[str]
+    credit_amount_cents: Optional[int]
+    credit_amount_currency: Optional[str]
+    refund_amount_cents: Optional[int]
+    refund_amount_currency: Optional[str]
+    fee: Optional[FeeResponse]
+
+class ItemsResponse(BaseModel):
+    __root__: List[ItemResponse]
+
+class CreditNoteResponse(BaseModel):
+    lago_id: Optional[str]
+    sequential_id: Optional[int]
+    number: Optional[str]
+    lago_invoice_id: Optional[str]
+    invoice_number: Optional[str]
+    credit_status: Optional[str]
+    refund_status: Optional[str]
+    reason: Optional[str]
+    total_amount_cents: Optional[int]
+    total_amount_currency: Optional[str]
+    credit_amount_cents: Optional[int]
+    credit_amount_currency: Optional[str]
+    balance_amount_cents: Optional[int]
+    balance_amount_currency: Optional[str]
+    refund_amount_cents: Optional[int]
+    refund_amount_currency: Optional[str]
+    vat_amount_cents: Optional[str]
+    vat_amount_currency: Optional[str]
+    sub_total_vat_excluded_amount_cents: Optional[str]
+    sub_total_vat_excluded_amount_currency: Optional[str]
+    file_url: Optional[str]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+    items: Optional[ItemsResponse]
+
+class Item(BaseModel):
+    credit_amount_cents: Optional[int]
+    refund_amount_cents: Optional[int]
+    fee_id: Optional[str]
+
+class Items(BaseModel):
+    __root__: List[Item]
+
+class CreditNote(BaseModel):
+    reason: Optional[str]
+    items: Optional[Items]
+
+class CreditNoteUpdate(BaseModel):
+    refund_status: Optional[str]

--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -1,10 +1,36 @@
 from pydantic import BaseModel, Field
-from typing import Optional
-
+from typing import Optional, List
+from .customer import CustomerResponse
+from .subscription import SubscriptionsResponse
 
 class InvoiceStatusChange(BaseModel):
     status: str
 
+class InvoiceItemResponse(BaseModel):
+    type: Optional[str]
+    code: Optional[str]
+    name: Optional[str]
+
+class FeeResponse(BaseModel):
+    lago_id: Optional[str]
+    item: Optional[InvoiceItemResponse]
+    amount_cents: Optional[int]
+    amount_currency: Optional[str]
+    vat_amount_cents: Optional[int]
+    vat_amount_currency: Optional[str]
+    units: Optional[float]
+    events_count: Optional[int]
+
+class FeesResponse(BaseModel):
+    __root__: List[FeeResponse]
+
+class CreditResponse(BaseModel):
+    amount_cents: Optional[int]
+    amount_currency: Optional[str]
+    item: Optional[InvoiceItemResponse]
+
+class CreditsResponse(BaseModel):
+    __root__: List[CreditResponse]
 
 class InvoiceResponse(BaseModel):
     lago_id: str
@@ -19,3 +45,7 @@ class InvoiceResponse(BaseModel):
     total_amount_cents: int
     total_amount_currency: str
     file_url: Optional[str]
+    customer: Optional[CustomerResponse]
+    subscriptions: Optional[SubscriptionsResponse]
+    fees: Optional[FeesResponse]
+    credits: Optional[CreditsResponse]

--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, List
 
 
 class Subscription(BaseModel):
@@ -28,3 +28,6 @@ class SubscriptionResponse(BaseModel):
     previous_plan_code: Optional[str]
     next_plan_code: Optional[str]
     downgrade_plan_date: Optional[str]
+
+class SubscriptionsResponse(BaseModel):
+    __root__: List[SubscriptionResponse]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,3 +14,4 @@ from tests.test_webhook_client import TestWebhookClient
 from tests.test_client import TestClient
 from tests.test_wallet_client import TestWalletClient
 from tests.test_wallet_transaction_client import TestWalletTransactionClient
+from tests.test_credit_note_client import TestCreditNoteClient

--- a/tests/fixtures/credit_note.json
+++ b/tests/fixtures/credit_note.json
@@ -1,0 +1,47 @@
+{
+  "credit_note": {
+    "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "sequential_id": 16,
+    "number": "LAG15-CN16",
+    "lago_invoice_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "invoice_number": "LAG15",
+    "credit_status": "available",
+    "refund_status": "pending",
+    "reason": "other",
+    "total_amount_cents": 240,
+    "total_amount_currency": "EUR",
+    "credit_amount_cents": 100,
+    "credit_amount_currency": "EUR",
+    "balance_amount_cents": 100,
+    "balance_amount_currency": "EUR",
+    "refund_amount_cents": 100,
+    "refund_amount_currency": "EUR",
+    "vat_amount_cents": 40,
+    "vat_amount_currency": "EUR",
+    "sub_total_vat_excluded_amount_cents": 200,
+    "sub_total_vat_excluded_amount_currency": "EUR",
+    "created_at": "2022-10-04 16:21:00",
+    "updated_at": "2022-10-04 16:21:00",
+    "items": [
+      {
+        "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        "fee": {
+          "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+          "item": {
+            "type": "charge",
+            "code": "seats",
+            "name": "User Seats"
+          },
+          "credit_amount_cents": 100,
+          "credit_amount_currency": "EUR",
+          "refund_amount_cents": 50,
+          "refund_amount_currency": "EUR",
+          "vat_amount_cents": 20,
+          "vat_amount_currency": "EUR",
+          "units": 12.6,
+          "events_count": 4
+        }
+      }
+    ]
+  }
+}

--- a/tests/fixtures/credit_note_index.json
+++ b/tests/fixtures/credit_note_index.json
@@ -1,0 +1,35 @@
+{
+  "credit_notes": [
+    {
+      "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+      "sequential_id": 16,
+      "number": "LAG15-CN16",
+      "lago_invoice_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+      "invoice_number": "LAG15",
+      "credit_status": "available",
+      "refund_status": "pending",
+      "reason": "other",
+      "total_amount_cents": 100,
+      "total_amount_currency": "EUR",
+      "credit_amount_cents": 100,
+      "credit_amount_currency": "EUR",
+      "balance_amount_cents": 100,
+      "balance_amount_currency": "EUR",
+      "refund_amount_cents": 100,
+      "refund_amount_currency": "EUR",
+      "vat_amount_cents": 40,
+      "vat_amount_currency": "EUR",
+      "sub_total_vat_excluded_amount_cents": 200,
+      "sub_total_vat_excluded_amount_currency": "EUR",
+      "created_at": "2022-10-04 16:21:00",
+      "updated_at": "2022-10-04 16:21:00"
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": null,
+    "total_pages": 8,
+    "total_count": 73
+  }
+}

--- a/tests/fixtures/invoice.json
+++ b/tests/fixtures/invoice.json
@@ -13,6 +13,75 @@
     "vat_amount_cents": 20,
     "vat_amount_currency": "EUR",
     "total_amount_cents": 120,
-    "total_amount_currency": "EUR"
+    "total_amount_currency": "EUR",
+    "customer": {
+      "lago_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
+      "external_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+      "address_line1": "5230 Penfield Ave",
+      "address_line2": null,
+      "city": "Woodland Hills",
+      "country": "US",
+      "created_at": "2022-04-29T08:59:51Z",
+      "email": "dinesh@piedpiper.test",
+      "legal_name": "Coleman-Blair",
+      "legal_number": "49-008-2965",
+      "logo_url": "http://hooli.com/logo.png",
+      "name": "Gavin Belson",
+      "phone": "1-171-883-3711 x245",
+      "state": "CA",
+      "url": "http://hooli.com",
+      "vat_rate": 12.5,
+      "zipcode": "91364",
+      "currency": "EUR",
+      "billing_configuration": {
+        "payment_provider": "stripe",
+        "provider_customer_id": "cus_12345"
+      }
+    },
+    "subscriptions": [
+      {
+        "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+        "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
+        "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        "canceled_at": "2022-04-29T08:59:51Z",
+        "created_at": "2022-04-29T08:59:51Z",
+        "plan_code": "eartha lynch",
+        "started_at": "2022-04-29T08:59:51Z",
+        "status": "active",
+        "billing_time": "anniversary",
+        "terminated_at": null,
+        "subscription_date": "2022-04-29",
+        "previous_plan_code": null,
+        "next_plan_code": null,
+        "downgrade_plan_date": null
+      }
+    ],
+    "fees": [
+      {
+        "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        "item": {
+          "type": "charge",
+          "code": "seats",
+          "name": "User Seats"
+        },
+        "amount_cents": 100,
+        "amount_currency": "EUR",
+        "vat_amount_cents": 20,
+        "vat_amount_currency": "EUR",
+        "units": 12.6,
+        "events_count": 4
+      }
+    ],
+    "credits": [
+      {
+        "amount_cents": 20,
+        "amount_currency": "EUR",
+        "item": {
+          "type": "coupon",
+          "code": "free_beer",
+          "name": "Free Beer"
+        }
+      }
+    ]
   }
 }

--- a/tests/test_credit_note_client.py
+++ b/tests/test_credit_note_client.py
@@ -1,0 +1,134 @@
+import unittest
+import requests_mock
+import os
+
+from lago_python_client.client import Client
+from lago_python_client.models.invoice import FeeResponse
+from lago_python_client.models.credit_note import Item, Items, CreditNote, CreditNoteUpdate
+from lago_python_client.clients.base_client import LagoApiError
+
+def credit_note_object():
+    item1 = Item(
+        fee_id="fee_id_1",
+        credit_amount_cents=10,
+        refund_amount_cents=10,
+    )
+
+    item2 = Item(
+        fee="fee_id_2",
+        credit_amount_cents=5,
+        refund_amount_cents=5,
+    )
+
+    return CreditNote(
+        lago_id="credit_note_id",
+        reason= 'other',
+        items= Items(__root__=[item1, item2])
+    )
+
+def credit_note_update_object():
+    return CreditNoteUpdate(refund_status='pending')
+
+def mock_response():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(current_dir, 'fixtures/credit_note.json')
+
+    with open(data_path, 'r') as credit_note_response:
+        return credit_note_response.read()
+
+def mock_collection_response():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(current_dir, 'fixtures/credit_note_index.json')
+
+    with open(data_path, 'r') as credit_notes_response:
+        return credit_notes_response.read()
+
+class TestCreditNoteClient(unittest.TestCase):
+    def test_valid_find_credit_note_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+        identifier = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/credit_notes/' + identifier, text=mock_response())
+            response = client.credit_notes().find(identifier)
+
+        self.assertEqual(response.lago_id, identifier)
+
+    def test_invalid_find_invoice_request(self):
+        client = Client(api_key='invalid')
+        identifier = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/credit_notes/' + identifier, status_code=404, text='')
+
+        with self.assertRaises(LagoApiError):
+            client.credit_notes().find(identifier)
+
+    def test_valid_find_all_credit_notes_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/credit_notes', text=mock_collection_response())
+            response = client.credit_notes().find_all({'per_page': 2, 'page': 1})
+
+        self.assertEqual(response['credit_notes'][0].lago_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+        self.assertEqual(response['meta']['current_page'], 1)
+
+    def test_valid_download_credit_note_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('POST',
+                            'https://api.getlago.com/api/v1/credit_notes/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba/download',
+                            text=mock_response())
+            response = client.credit_notes().download('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+
+        self.assertEqual(response.lago_id, '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+
+    def test_valid_create_credit_note_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('POST', 'https://api.getlago.com/api/v1/credit_notes', text=mock_response())
+            response = client.credit_notes().create(credit_note_object())
+
+        self.assertEqual(response.lago_id, "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba")
+        self.assertEqual(response.refund_status, 'pending')
+
+    def test_invalid_create_credit_note_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('POST', 'https://api.getlago.com/api/v1/credit_notes', status_code=422, text='')
+
+            with self.assertRaises(LagoApiError):
+                client.credit_notes().create(credit_note_object())
+
+    def test_valid_update_credit_note_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+        credit_note_id = 'credit-note-id'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('PUT',
+                           'https://api.getlago.com/api/v1/credit_notes/' + credit_note_id,
+                           text=mock_response())
+            response = client.credit_notes().update(credit_note_update_object(), credit_note_id)
+
+        self.assertEqual(response.lago_id, "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba")
+        self.assertEqual(response.refund_status, 'pending')
+
+    def test_valid_void_credit_note_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+        credit_note_id = 'credit-note-id'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('PUT',
+                           'https://api.getlago.com/api/v1/credit_notes/' + credit_note_id + '/void',
+                           text=mock_response())
+            response = client.credit_notes().void(credit_note_id)
+
+        self.assertEqual(response.lago_id, "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba")
+        self.assertEqual(response.refund_status, 'pending')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds the credit note API clients

Related to https://github.com/getlago/lago-api/pull/505