### PR TITLE
feat(groups): Add group on billable metric

### DIFF
--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -1,6 +1,6 @@
 from lago_python_client.models.applied_add_on import AppliedAddOn
 from lago_python_client.models.applied_coupon import AppliedCoupon
-from lago_python_client.models.billable_metric import BillableMetric
+from lago_python_client.models.billable_metric import BillableMetric, BillableMetricGroup
 from lago_python_client.models.coupon import Coupon
 from lago_python_client.models.plan import Plan, Charges, Charge
 from lago_python_client.models.add_on import AddOn

--- a/lago_python_client/models/billable_metric.py
+++ b/lago_python_client/models/billable_metric.py
@@ -1,6 +1,9 @@
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, List, Union
 
+class BillableMetricGroup(BaseModel):
+    key: Optional[str]
+    values: Optional[List[Union[str, dict]]]
 
 class BillableMetric(BaseModel):
     name: Optional[str]
@@ -8,7 +11,7 @@ class BillableMetric(BaseModel):
     description: Optional[str]
     aggregation_type: Optional[str]
     field_name: Optional[str]
-
+    group: Optional[BillableMetricGroup]
 
 class BillableMetricResponse(BaseModel):
     lago_id: str
@@ -18,3 +21,4 @@ class BillableMetricResponse(BaseModel):
     aggregation_type: Optional[str]
     field_name: Optional[str]
     created_at: str
+    group: BillableMetricGroup

--- a/tests/fixtures/billable_metric.json
+++ b/tests/fixtures/billable_metric.json
@@ -6,6 +6,10 @@
     "description": "description",
     "aggregation_type": "sum_agg",
     "field_name": "amount_sum",
-    "created_at": "2022-04-29T08:59:51Z"
+    "created_at": "2022-04-29T08:59:51Z",
+    "group": {
+      "key": "country",
+      "values": ["france", "italy", "spain"]
+    }
   }
 }

--- a/tests/fixtures/billable_metric_index.json
+++ b/tests/fixtures/billable_metric_index.json
@@ -1,13 +1,14 @@
 {
   "billable_metrics": [
     {
-    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1000",
-    "name": "bm_name",
-    "code": "bm_code",
-    "description": "description",
-    "aggregation_type": "sum_agg",
-    "field_name": "amount_sum",
-    "created_at": "2022-04-29T08:59:51Z"
+      "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1000",
+      "name": "bm_name",
+      "code": "bm_code",
+      "description": "description",
+      "aggregation_type": "sum_agg",
+      "field_name": "amount_sum",
+      "created_at": "2022-04-29T08:59:51Z",
+      "group": {}
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314a11111",
@@ -16,7 +17,8 @@
       "description": "description2",
       "aggregation_type": "sum_agg",
       "field_name": "amount_sum",
-      "created_at": "2022-04-30T08:59:51Z"
+      "created_at": "2022-04-30T08:59:51Z",
+      "group": {}
     }
   ],
   "meta": {

--- a/tests/test_billable_metric_client.py
+++ b/tests/test_billable_metric_client.py
@@ -3,7 +3,7 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
-from lago_python_client.models import BillableMetric
+from lago_python_client.models import BillableMetric, BillableMetricGroup
 from lago_python_client.clients.base_client import LagoApiError
 
 
@@ -13,9 +13,12 @@ def billable_metric_object():
         code='code_first',
         description='desc',
         aggregation_type='sum_agg',
-        field_name='amount_sum'
+        field_name='amount_sum',
+        group=group()
     )
 
+def group():
+    return BillableMetricGroup(key='country', values=['france', 'italy', 'spain'])
 
 def mock_response():
     this_dir = os.path.dirname(os.path.abspath(__file__))
@@ -43,6 +46,7 @@ class TestBillableMetricClient(unittest.TestCase):
 
         self.assertEqual(response.lago_id, 'b7ab2926-1de8-4428-9bcd-779314ac129b')
         self.assertEqual(response.code, 'bm_code')
+        self.assertEqual(response.group, group())
 
     def test_invalid_create_billable_metric_request(self):
         client = Client(api_key='invalid')


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

This PR adds `group` on `billable_metric`.