### PR TITLE
misc: Use graduated ranges as hash

### DIFF
--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -5,7 +5,7 @@ class Charge(BaseModel):
     id: Optional[str]
     billable_metric_id: Optional[str]
     charge_model: Optional[str]
-    properties: Optional[Union[dict, list]]
+    properties: Optional[dict]
 
 class Charges(BaseModel):
     __root__: List[Charge]

--- a/tests/fixtures/graduated_plan.json
+++ b/tests/fixtures/graduated_plan.json
@@ -18,20 +18,22 @@
         "created_at": "2022-07-01T14:47:14Z",
         "amount_currency": "EUR",
         "charge_model": "standard",
-        "properties": [
-          {
-              "to_value": 1,
-              "from_value": 0,
-              "flat_amount": "0",
-              "per_unit_amount": "0"
-          },
-          {
-              "to_value": null,
-              "from_value": 2,
-              "flat_amount": "0",
-              "per_unit_amount": "3200"
-          }
-        ]
+        "properties": {
+          "graduated_ranges": [
+            {
+                "to_value": 1,
+                "from_value": 0,
+                "flat_amount": "0",
+                "per_unit_amount": "0"
+            },
+            {
+                "to_value": null,
+                "from_value": 2,
+                "flat_amount": "0",
+                "per_unit_amount": "3200"
+            }
+          ]
+        }
       }
     ]
   }

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -34,20 +34,22 @@ def graduated_plan_object():
         billable_metric_id='id',
         charge_model='graduated',
         amount_currency='EUR',
-        properties = [
-            {
-                'to_value': 1,
-                'from_value': 0,
-                'flat_amount': "0",
-                'per_unit_amount': "0"
-            },
-            {
-                'to_value': None,
-                'from_value': 2,
-                'flat_amount': "0",
-                'per_unit_amount': "3200"
-            }
-        ]
+        properties = {
+            'graduated_ranges': [
+                {
+                    'to_value': 1,
+                    'from_value': 0,
+                    'flat_amount': "0",
+                    'per_unit_amount': "0"
+                },
+                {
+                    'to_value': None,
+                    'from_value': 2,
+                    'flat_amount': "0",
+                    'per_unit_amount': "3200"
+                }
+            ]
+        }
     )
     charges = Charges(__root__=[charge])
 
@@ -102,7 +104,7 @@ class TestPlanClient(unittest.TestCase):
         with requests_mock.Mocker() as m:
             m.register_uri('POST', 'https://api.getlago.com/api/v1/plans', text=mock_graduated_response())
             response = client.plans().create(graduated_plan_object())
-        
+
         self.assertEqual(response.lago_id, 'b7ab2926-1de8-4428-9bcd-779314ac129b')
         self.assertEqual(response.code, 'plan_code')
 


### PR DESCRIPTION
## Context

In order to be consistent between all charge models, we want to store `properties` by using the same type.

## Description

The goal of this MR is to update `properties` from `array` to `hash` for graduated charges.