### PR TITLE
feat(groups): Add group_properties on charge and groups endpoint

### DIFF
--- a/lago_python_client/client.py
+++ b/lago_python_client/client.py
@@ -2,6 +2,7 @@ from lago_python_client.clients.applied_add_on_client import AppliedAddOnClient
 from lago_python_client.clients.applied_coupon_client import AppliedCouponClient
 from lago_python_client.clients.billable_metric_client import BillableMetricClient
 from lago_python_client.clients.coupon_client import CouponClient
+from lago_python_client.clients.group_client import GroupClient
 from lago_python_client.clients.plan_client import PlanClient
 from lago_python_client.clients.add_on_client import AddOnClient
 from lago_python_client.clients.organization_client import OrganizationClient
@@ -31,6 +32,9 @@ class Client:
 
     def events(self):
         return EventClient(self.base_api_url(), self.api_key)
+
+    def groups(self):
+        return GroupClient(self.base_api_url(), self.api_key)
 
     def subscriptions(self):
         return SubscriptionClient(self.base_api_url(), self.api_key)

--- a/lago_python_client/clients/group_client.py
+++ b/lago_python_client/clients/group_client.py
@@ -1,0 +1,29 @@
+import requests
+
+from .base_client import BaseClient
+from lago_python_client.models.group import GroupResponse
+from typing import Dict
+from urllib.parse import urljoin, urlencode
+from requests import Response
+
+class GroupClient(BaseClient):
+    def api_resource(self):
+        return 'groups'
+
+    def root_name(self):
+        return 'group'
+
+    def prepare_response(self, data: Dict):
+        return GroupResponse.parse_obj(data)
+
+    def find_all(self, metric_code: str, options: Dict = None):
+        if options:
+            api_resource = 'billable_metrics/' + metric_code + '/groups?' + urlencode(options)
+        else:
+            api_resource = 'billable_metrics/' + metric_code + '/groups'
+
+        query_url = urljoin(self.base_url, api_resource)
+        api_response = requests.get(query_url, headers=self.headers())
+        data = self.handle_response(api_response).json()
+
+        return self.prepare_index_response(data)

--- a/lago_python_client/models/group.py
+++ b/lago_python_client/models/group.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class Group(BaseModel):
+    lago_id: Optional[str]
+    key: Optional[str]
+    value: Optional[str]
+
+class GroupResponse(BaseModel):
+    lago_id: str
+    key: str
+    value: str

--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -1,11 +1,16 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List, Union
 
+class GroupProperties(BaseModel):
+    group_id: Optional[str]
+    values: Optional[dict]
+
 class Charge(BaseModel):
     id: Optional[str]
     billable_metric_id: Optional[str]
     charge_model: Optional[str]
     properties: Optional[dict]
+    group_properties: Optional[GroupProperties]
 
 class Charges(BaseModel):
     __root__: List[Charge]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ from tests.test_applied_coupon_client import TestAppliedCouponClient
 from tests.test_applied_add_on_client import TestAppliedAddOnClient
 from tests.test_billable_metric_client import TestBillableMetricClient
 from tests.test_coupon_client import TestCouponClient
+from tests.test_group_client import TestGroupClient
 from tests.test_plan_client import TestPlanClient
 from tests.test_add_on_client import TestAddOnClient
 from tests.test_organization_client import TestOrganizationClient

--- a/tests/fixtures/group_index.json
+++ b/tests/fixtures/group_index.json
@@ -1,0 +1,26 @@
+{
+  "groups": [
+    {
+      "lago_id": "12345678-1de8-4428-9bcd-779314ac1111",
+      "key": "aws",
+      "value": "europe"
+    },
+    {
+      "lago_id": "87654321-1de8-4428-9bcd-779314ac1111",
+      "key": "google",
+      "value": "usa"
+    },
+    {
+      "lago_id": "12435687-1de8-4428-9bcd-779314ac1111",
+      "key": "google",
+      "value": "europe"
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": null,
+    "total_pages": 8,
+    "total_count": 73
+  }
+}

--- a/tests/fixtures/plan_index.json
+++ b/tests/fixtures/plan_index.json
@@ -19,9 +19,12 @@
           "created_at": "2022-07-01T14:47:14Z",
           "amount_currency": "EUR",
           "charge_model": "standard",
-          "properties": {
-            "amount": "0.22"
-          }
+          "group_properties": [
+            {
+              "group_id": "gfc1e851-5be6-4343-a0ee-39a81d8b4ee1",
+              "values": { "amount": "0.22" }
+            }
+          ]
         }
       ]
     },

--- a/tests/test_group_client.py
+++ b/tests/test_group_client.py
@@ -1,0 +1,27 @@
+import unittest
+import requests_mock
+import os
+
+from lago_python_client.client import Client
+
+def mock_collection_response():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(current_dir, 'fixtures/group_index.json')
+
+    with open(data_path, 'r') as groups_response:
+        return groups_response.read()
+
+class TestGroupClient(unittest.TestCase):
+    def test_valid_find_all_groups_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+        with requests_mock.Mocker() as m:
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/billable_metrics/bm_code/groups', text=mock_collection_response())
+            response = client.groups().find_all('bm_code', {'per_page': 2, 'page': 1})
+
+        self.assertEqual(response['groups'][0].lago_id, '12345678-1de8-4428-9bcd-779314ac1111')
+        self.assertEqual(response['meta']['current_page'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -12,9 +12,14 @@ def plan_object():
         billable_metric_id='id',
         charge_model='standard',
         amount_currency='EUR',
-        properties={
-            'amount': '0.22'
-        }
+        group_properties = [
+            {
+                'group_id': 'id',
+                'values': {
+                    'amount': '0.22'
+                }
+            }
+        ]
     )
     charges = Charges(__root__=[charge])
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

This PR adds documentation for:
- `group_properties` on `charge` creation
- `GET billables_metrics/:code/groups` endpoint
