### PR TITLE
misc: Move fields to billing configuration

### DIFF
--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -4,9 +4,9 @@ from lago_python_client.models.billable_metric import BillableMetric, BillableMe
 from lago_python_client.models.coupon import Coupon
 from lago_python_client.models.plan import Plan, Charges, Charge
 from lago_python_client.models.add_on import AddOn
-from lago_python_client.models.organization import Organization
+from lago_python_client.models.organization import Organization, OrganizationBillingConfiguration
 from lago_python_client.models.event import Event, BatchEvent
-from lago_python_client.models.customer import Customer, BillingConfiguration
+from lago_python_client.models.customer import Customer, CustomerBillingConfiguration
 from lago_python_client.models.invoice import InvoiceStatusChange
 from lago_python_client.models.subscription import Subscription
 from lago_python_client.models.customer_usage import Metric, ChargeObject, ChargeUsage, CustomerUsageResponse

--- a/lago_python_client/models/customer.py
+++ b/lago_python_client/models/customer.py
@@ -2,10 +2,11 @@ from pydantic import BaseModel, Field
 from typing import Optional
 
 
-class BillingConfiguration(BaseModel):
+class CustomerBillingConfiguration(BaseModel):
     payment_provider: Optional[str]
     provider_customer_id: Optional[str]
     sync: Optional[bool]
+    vat_rate: Optional[float]
 
 
 class Customer(BaseModel):
@@ -23,9 +24,8 @@ class Customer(BaseModel):
     phone: Optional[str]
     state: Optional[str]
     url: Optional[str]
-    vat_rate: Optional[float]
     zipcode: Optional[str]
-    billing_configuration: Optional[BillingConfiguration]
+    billing_configuration: Optional[CustomerBillingConfiguration]
 
 
 class CustomerResponse(BaseModel):
@@ -45,6 +45,5 @@ class CustomerResponse(BaseModel):
     phone: Optional[str]
     state: Optional[str]
     url: Optional[str]
-    vat_rate: Optional[float]
     zipcode: Optional[str]
-    billing_configuration: Optional[BillingConfiguration]
+    billing_configuration: Optional[CustomerBillingConfiguration]

--- a/lago_python_client/models/organization.py
+++ b/lago_python_client/models/organization.py
@@ -2,9 +2,13 @@ from pydantic import BaseModel, Field
 from typing import Optional
 
 
+class OrganizationBillingConfiguration(BaseModel):
+    invoice_footer: Optional[str]
+    vat_rate: Optional[float]
+
+
 class Organization(BaseModel):
     webhook_url: Optional[str]
-    vat_rate: Optional[float]
     country: Optional[str]
     address_line1: Optional[str]
     address_line2: Optional[str]
@@ -14,14 +18,13 @@ class Organization(BaseModel):
     city: Optional[str]
     legal_name: Optional[str]
     legal_number: Optional[str]
-    invoice_footer: Optional[str]
+    billing_configuration: Optional[OrganizationBillingConfiguration]
 
 
 class OrganizationResponse(BaseModel):
     name: str
     created_at: str
     webhook_url: Optional[str]
-    vat_rate: Optional[float]
     country: Optional[str]
     address_line1: Optional[str]
     address_line2: Optional[str]
@@ -31,4 +34,4 @@ class OrganizationResponse(BaseModel):
     city: Optional[str]
     legal_name: Optional[str]
     legal_number: Optional[str]
-    invoice_footer: Optional[str]
+    billing_configuration: Optional[OrganizationBillingConfiguration]

--- a/tests/fixtures/customer.json
+++ b/tests/fixtures/customer.json
@@ -15,12 +15,12 @@
     "phone": "1-171-883-3711 x245",
     "state": "CA",
     "url": "http://hooli.com",
-    "vat_rate": 12.5,
     "zipcode": "91364",
     "currency": "EUR",
     "billing_configuration": {
       "payment_provider": "stripe",
-      "provider_customer_id": "cus_12345"
+      "provider_customer_id": "cus_12345",
+      "vat_rate": 12.5
     }
   }
 }

--- a/tests/fixtures/organization.json
+++ b/tests/fixtures/organization.json
@@ -3,7 +3,6 @@
     "name": "Hooli",
     "created_at": "2022-05-02T13:04:09Z",
     "webhook_url": "https://test-example.example",
-    "vat_rate": 15.0,
     "country": null,
     "address_line1": null,
     "address_line2": null,
@@ -13,6 +12,9 @@
     "city": "city125",
     "legal_name": null,
     "legal_number": null,
-    "invoice_footer": null
+    "billing_configuration": {
+      "invoice_footer": null,
+      "vat_rate": 15.0
+    }
   }
 }

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -3,7 +3,7 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
-from lago_python_client.models import Customer, BillingConfiguration
+from lago_python_client.models import Customer, CustomerBillingConfiguration
 from lago_python_client.clients.base_client import LagoApiError
 
 
@@ -12,9 +12,10 @@ def create_customer():
         external_id='5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba',
         name='Gavin Belson',
         currency='EUR',
-        billing_configuration=BillingConfiguration(
+        billing_configuration=CustomerBillingConfiguration(
             payment_provider='stripe',
-            provider_customer_id='cus_12345'
+            provider_customer_id='cus_12345',
+            vat_rate=12.5
         )
     )
 
@@ -39,6 +40,7 @@ class TestCustomerClient(unittest.TestCase):
         self.assertEqual(response.currency, 'EUR')
         self.assertEqual(response.billing_configuration.payment_provider, 'stripe')
         self.assertEqual(response.billing_configuration.provider_customer_id, 'cus_12345')
+        self.assertEqual(response.billing_configuration.vat_rate, 12.5)
 
     def test_invalid_create_customers_request(self):
         client = Client(api_key='invalid')

--- a/tests/test_organization_client.py
+++ b/tests/test_organization_client.py
@@ -3,14 +3,17 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
-from lago_python_client.models import Organization
+from lago_python_client.models import Organization, OrganizationBillingConfiguration
 from lago_python_client.clients.base_client import LagoApiError
 
 
 def organization_object():
     return Organization(
         webhook_url="https://test-example.example",
-        vat_rate=15.0,
+        billing_configuration=OrganizationBillingConfiguration(
+            invoice_footer='footer',
+            vat_rate=20
+        )
     )
 
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Description

The goal of this PR is to move fields related to Billing or Invoice into `billing_configuration`.

For customer: `vat_rate`.

For organization: `invoice_footer`, `vat_rate`.
