### PR TITLE
feat(timezones): Update clients to support customer timezones

### DIFF
--- a/lago_python_client/models/coupon.py
+++ b/lago_python_client/models/coupon.py
@@ -8,7 +8,7 @@ class Coupon(BaseModel):
     amount_cents: Optional[int]
     amount_currency: Optional[str]
     expiration: Optional[str]
-    expiration_date: Optional[str]
+    expiration_at: Optional[str]
     percentage_rate: Optional[float]
     coupon_type: Optional[str]
     reusable: Optional[bool]
@@ -24,7 +24,7 @@ class CouponResponse(BaseModel):
     amount_currency: str
     created_at: str
     expiration: str
-    expiration_date: Optional[str]
+    expiration_at: Optional[str]
     percentage_rate: Optional[float]
     coupon_type: Optional[str]
     reusable: Optional[bool]

--- a/lago_python_client/models/customer.py
+++ b/lago_python_client/models/customer.py
@@ -24,6 +24,7 @@ class Customer(BaseModel):
     name: str
     phone: Optional[str]
     state: Optional[str]
+    timezone: Optional[str]
     url: Optional[str]
     zipcode: Optional[str]
     billing_configuration: Optional[CustomerBillingConfiguration]
@@ -45,6 +46,8 @@ class CustomerResponse(BaseModel):
     name: str
     phone: Optional[str]
     state: Optional[str]
+    timezone: Optional[str]
+    applicable_timezone: str
     url: Optional[str]
     zipcode: Optional[str]
     billing_configuration: Optional[CustomerBillingConfiguration]

--- a/lago_python_client/models/customer_usage.py
+++ b/lago_python_client/models/customer_usage.py
@@ -23,8 +23,8 @@ class ChargeUsage(BaseModel):
 
 
 class CustomerUsageResponse(BaseModel):
-  from_date: str
-  to_date: str
+  from_datetime: str
+  to_datetime: str
   issuing_date: str
   amount_cents: int
   amount_currency: str

--- a/lago_python_client/models/organization.py
+++ b/lago_python_client/models/organization.py
@@ -18,6 +18,7 @@ class Organization(BaseModel):
     city: Optional[str]
     legal_name: Optional[str]
     legal_number: Optional[str]
+    timezone: Optional[str]
     billing_configuration: Optional[OrganizationBillingConfiguration]
 
 
@@ -34,4 +35,5 @@ class OrganizationResponse(BaseModel):
     city: Optional[str]
     legal_name: Optional[str]
     legal_number: Optional[str]
+    timezone: Optional[str]
     billing_configuration: Optional[OrganizationBillingConfiguration]

--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -8,7 +8,7 @@ class Wallet(BaseModel):
     name: Optional[str]
     paid_credits: Optional[str]
     granted_credits: Optional[str]
-    expiration_date: Optional[str]
+    expiration_at: Optional[str]
 
 
 class WalletResponse(BaseModel):
@@ -23,7 +23,7 @@ class WalletResponse(BaseModel):
     balance: str
     consumed_credits: str
     created_at: str
-    expiration_date: Optional[str]
+    expiration_at: Optional[str]
     last_balance_sync_at: Optional[str]
     last_consumed_credit_at: Optional[str]
     terminated_at: Optional[str]

--- a/tests/fixtures/coupon.json
+++ b/tests/fixtures/coupon.json
@@ -6,7 +6,7 @@
     "amount_cents": 5000,
     "amount_currency": "USD",
     "expiration": "no_expiration",
-    "expiration_date": "2022-08-08",
+    "expiration_at": "2022-08-08T23:59:59Z",
     "percentage_rate": null,
     "frequency": "once",
     "frequency_duration": null,

--- a/tests/fixtures/customer.json
+++ b/tests/fixtures/customer.json
@@ -17,6 +17,8 @@
     "url": "http://hooli.com",
     "zipcode": "91364",
     "currency": "EUR",
+    "timezone": "Europe/Paris",
+    "applicable_timezone": "Europe/Paris",
     "billing_configuration": {
       "payment_provider": "stripe",
       "provider_customer_id": "cus_12345",

--- a/tests/fixtures/customer_usage.json
+++ b/tests/fixtures/customer_usage.json
@@ -1,7 +1,7 @@
 {
   "customer_usage": {
-    "from_date": "2022-07-01",
-    "to_date": "2022-07-31",
+    "from_datetime": "2022-07-01T00:00:00Z",
+    "to_datetime": "2022-07-31T23:59:59Z",
     "issuing_date": "2022-08-01",
     "amount_cents": 123,
     "amount_currency": "EUR",

--- a/tests/fixtures/invoice.json
+++ b/tests/fixtures/invoice.json
@@ -33,6 +33,8 @@
       "vat_rate": 12.5,
       "zipcode": "91364",
       "currency": "EUR",
+      "timezone": "Europe/Paris",
+      "applicable_timezone": "Europe/Paris",
       "billing_configuration": {
         "payment_provider": "stripe",
         "provider_customer_id": "cus_12345"

--- a/tests/fixtures/organization.json
+++ b/tests/fixtures/organization.json
@@ -12,6 +12,7 @@
     "city": "city125",
     "legal_name": null,
     "legal_number": null,
+    "timezone": "America/New_York",
     "billing_configuration": {
       "invoice_footer": null,
       "vat_rate": 15.0

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -11,7 +11,7 @@
     "balance": "10",
     "consumed_credits": "2",
     "created_at": "2022-04-29T08:59:51Z",
-    "expiration_date": null,
+    "expiration_at": null,
     "last_balance_sync_at": "2022-04-29T08:59:51Z",
     "last_consumed_credit_at": "2022-04-29T08:59:51Z"
   }

--- a/tests/test_coupon_client.py
+++ b/tests/test_coupon_client.py
@@ -14,7 +14,7 @@ def coupon_object():
         amount_cents=1000,
         amount_currency='EUR',
         expiration='no_expiration',
-        expiration_date="2022-08-08",
+        expiration_at="2022-08-08T23:59:59Z",
         coupon_type="fixed_amount",
         reusable=False,
         frequency="once"

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -63,7 +63,7 @@ class TestCustomerClient(unittest.TestCase):
                            text=mock_response('customer_usage'))
             response = client.customers().current_usage('external_customer_id', '123')
 
-        self.assertEqual(response.from_date, '2022-07-01')
+        self.assertEqual(response.from_datetime, '2022-07-01T00:00:00Z')
         self.assertEqual(len(response.charges_usage), 1)
         self.assertEqual(response.charges_usage[0].units, 1.0)
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR adds:
- Support for timezone at customer level
- Support for timezone at organization level
- Replace `expiration_date` by `expiration_at` on coupons
- Replace `expiration_date` by `expiration_at` on wallets
- Replace `from_date` and `to_date` by `from_datetime` and `to_datetime` on customer usage
