### PR TITLE
feat (webhooks): add support for webhook public key changes

### DIFF
--- a/lago_python_client/clients/webhook_client.py
+++ b/lago_python_client/clients/webhook_client.py
@@ -6,16 +6,13 @@ from .base_client import BaseClient
 
 
 class WebhookClient(BaseClient):
+    def root_name(self):
+        return 'webhook'
+
     def public_key(self):
         query_url = urljoin(self.base_url, 'webhooks/public_key')
 
         api_response = requests.get(query_url, headers=self.headers())
-        coded_response = self.handle_response(api_response).text
+        data = self.handle_response(api_response).json().get(self.root_name())
 
-        return base64.b64decode(coded_response)
-
-    def headers(self):
-        bearer = "Bearer " + self.api_key
-        headers = {'Authorization': bearer}
-
-        return headers
+        return base64.b64decode(data['public_key'])

--- a/lago_python_client/clients/webhook_client.py
+++ b/lago_python_client/clients/webhook_client.py
@@ -10,7 +10,7 @@ class WebhookClient(BaseClient):
         return 'webhook'
 
     def public_key(self):
-        query_url = urljoin(self.base_url, 'webhooks/public_key')
+        query_url = urljoin(self.base_url, 'webhooks/json_public_key')
 
         api_response = requests.get(query_url, headers=self.headers())
         data = self.handle_response(api_response).json().get(self.root_name())

--- a/tests/fixtures/webhook.json
+++ b/tests/fixtures/webhook.json
@@ -1,0 +1,5 @@
+{
+  "webhook": {
+    "public_key": "a2V5"
+  }
+}

--- a/tests/test_webhook_client.py
+++ b/tests/test_webhook_client.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import requests_mock
 
@@ -5,12 +6,20 @@ from lago_python_client.client import Client
 from lago_python_client.clients.base_client import LagoApiError
 
 
+def mock_response():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(this_dir, 'fixtures/webhook.json')
+
+    with open(data_path, 'r') as webhook_response:
+        return webhook_response.read()
+
+
 class TestWebhookClient(unittest.TestCase):
     def test_valid_public_key_request(self):
         client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
         with requests_mock.Mocker() as m:
-            m.register_uri('GET', 'https://api.getlago.com/api/v1/webhooks/public_key', text='a2V5')
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/webhooks/public_key', text=mock_response())
             response = client.webhooks().public_key()
 
         self.assertEqual(response, b'key')

--- a/tests/test_webhook_client.py
+++ b/tests/test_webhook_client.py
@@ -19,7 +19,7 @@ class TestWebhookClient(unittest.TestCase):
         client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
         with requests_mock.Mocker() as m:
-            m.register_uri('GET', 'https://api.getlago.com/api/v1/webhooks/public_key', text=mock_response())
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/webhooks/json_public_key', text=mock_response())
             response = client.webhooks().public_key()
 
         self.assertEqual(response, b'key')
@@ -28,7 +28,7 @@ class TestWebhookClient(unittest.TestCase):
         client = Client(api_key='invalid')
 
         with requests_mock.Mocker() as m:
-            m.register_uri('GET', 'https://api.getlago.com/api/v1/webhooks/public_key', status_code=401, text='')
+            m.register_uri('GET', 'https://api.getlago.com/api/v1/webhooks/json_public_key', status_code=401, text='')
 
             with self.assertRaises(LagoApiError):
                 client.webhooks().public_key()


### PR DESCRIPTION
`/api/v1/webhooks/public_key` endpoint changed reponse to json format:
{'webhook': {'public_key': 'public key encoded'}}

This PR adds support for mentioned changes