### PR TITLE
feat(delete_bm): Update response and tests for billable metric deletion

### DIFF
--- a/lago_python_client/models/billable_metric.py
+++ b/lago_python_client/models/billable_metric.py
@@ -22,3 +22,5 @@ class BillableMetricResponse(BaseModel):
     field_name: Optional[str]
     created_at: str
     group: BillableMetricGroup
+    active_subscriptions_count: int
+    draft_invoices_count: int

--- a/tests/fixtures/billable_metric.json
+++ b/tests/fixtures/billable_metric.json
@@ -10,6 +10,8 @@
     "group": {
       "key": "country",
       "values": ["france", "italy", "spain"]
-    }
+    },
+    "active_subscriptions_count": 0,
+    "draft_invoices_count": 0
   }
 }

--- a/tests/fixtures/billable_metric_index.json
+++ b/tests/fixtures/billable_metric_index.json
@@ -8,7 +8,9 @@
       "aggregation_type": "sum_agg",
       "field_name": "amount_sum",
       "created_at": "2022-04-29T08:59:51Z",
-      "group": {}
+      "group": {},
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314a11111",
@@ -18,7 +20,9 @@
       "aggregation_type": "sum_agg",
       "field_name": "amount_sum",
       "created_at": "2022-04-30T08:59:51Z",
-      "group": {}
+      "group": {},
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0
     }
   ],
   "meta": {


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to add on the billable metric response:
- `activeSubscriptionsCount`
- `draftInvoicesCount`

These fields are used to know the impact of deleting billable metric.