### PR TITLE
feat(delete_plan): Add subscription and invoice counters to plans

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Lago
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a python wrapper for Lago API
 
 [![PyPI version](https://badge.fury.io/py/lago-python-client.svg)](https://badge.fury.io/py/lago-python-client)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://spdx.org/licenses/MIT.html)
 
 ## Installation
 
@@ -37,7 +38,7 @@ The Lago documentation is available at [doc.getlago.com](https://doc.getlago.com
 * [#55](https://github.com/getlago/lago-python-client/pull/55) -- Error handling (`LagoApiError`)
 
 
-Example, creating wallet: 
+Example, creating wallet:
 
 ```
 try:
@@ -74,4 +75,4 @@ The contribution documentation is available [here](https://github.com/getlago/la
 
 ## License
 
-Lago Python client is distributed under [AGPL-3.0](LICENSE).
+Lago Python client is distributed under [MIT license](LICENSE).

--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -41,3 +41,5 @@ class PlanResponse(BaseModel):
     pay_in_advance: Optional[bool]
     bill_charges_monthly: Optional[bool]
     charges: Optional[Charges]
+    active_subscriptions_count: int
+    draft_invoices_count: int

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ long_description_content_type = text/markdown
 url = https://github.com/getlago/lago-python-client
 classifiers =
     Programming Language :: Python :: 3
-    License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)
+    License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Topic :: Software Development
 

--- a/tests/fixtures/graduated_plan.json
+++ b/tests/fixtures/graduated_plan.json
@@ -11,6 +11,8 @@
     "trial_period": 3.0,
     "pay_in_advance": true,
     "bill_charges_monthly": null,
+    "active_subscriptions_count": 0,
+    "draft_invoices_count": 0,
     "charges": [
       {
         "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -11,6 +11,8 @@
     "trial_period": 3.0,
     "pay_in_advance": true,
     "bill_charges_monthly": null,
+    "active_subscriptions_count": 0,
+    "draft_invoices_count": 0,
     "charges": [
       {
         "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",

--- a/tests/fixtures/plan_index.json
+++ b/tests/fixtures/plan_index.json
@@ -12,6 +12,8 @@
       "trial_period": 3.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0,
       "charges": [
         {
           "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
@@ -40,6 +42,8 @@
       "trial_period": 2.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0,
       "charges": [
         {
           "lago_id": "dfdc725d-6341-4d61-831e-4ac9ccd509c0",
@@ -65,6 +69,8 @@
       "trial_period": 0.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
+      "active_subscriptions_count": 0,
+      "draft_invoices_count": 0,
       "charges": []
     }
   ],


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to add two counters in the plan response:
- `active_subscription_count`
- `draft_invoice_count`