### PR TITLE
feat(destroy_coupon): Ability to terminate an applied coupon

### DIFF
--- a/lago_python_client/clients/applied_coupon_client.py
+++ b/lago_python_client/clients/applied_coupon_client.py
@@ -1,7 +1,10 @@
+import requests
+
 from .base_client import BaseClient
 from lago_python_client.models.applied_coupon import AppliedCouponResponse
 from typing import Dict
-
+from urllib.parse import urljoin
+from requests import Response
 
 class AppliedCouponClient(BaseClient):
     def api_resource(self):
@@ -12,3 +15,12 @@ class AppliedCouponClient(BaseClient):
 
     def prepare_response(self, data: Dict):
         return AppliedCouponResponse.parse_obj(data)
+
+    def destroy(self, external_customer_id: str, coupon_code: str):
+        api_resource = 'customers/' + external_customer_id + '/coupons/' + coupon_code
+        query_url = urljoin(self.base_url, api_resource)
+
+        api_response = requests.delete(query_url, headers=self.headers())
+        data = self.handle_response(api_response).json().get(self.root_name())
+
+        return self.prepare_response(data)

--- a/tests/test_applied_coupon_client.py
+++ b/tests/test_applied_coupon_client.py
@@ -78,6 +78,35 @@ class TestAppliedCouponClient(unittest.TestCase):
             with self.assertRaises(LagoApiError):
                 client.applied_coupons().find_all()
 
+    def test_valid_destroy_applied_coupon_request(self):
+        client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+        external_customer_id = 'external_customer_id'
+        coupon_code = 'coupon_code'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                'DELETE',
+                'https://api.getlago.com/api/v1/customers/' + external_customer_id + '/coupons/' + coupon_code,
+                text=mock_response()
+            )
+            response = client.applied_coupons().destroy(external_customer_id, coupon_code)
+
+        self.assertEqual(response.lago_id, 'b7ab2926-1de8-4428-9bcd-779314ac129b')
+
+    def test_invalid_destroy_applied_coupon_request(self):
+        client = Client(api_key='invalid')
+        external_customer_id = 'external_customer_id'
+        coupon_code = 'coupon_code'
+
+        with requests_mock.Mocker() as m:
+            m.register_uri(
+                'DELETE',
+                'https://api.getlago.com/api/v1/customers/' + external_customer_id + '/coupons/' + coupon_code,
+                status_code=404,
+                text=''
+            )
+            with self.assertRaises(LagoApiError):
+                client.applied_coupons().destroy(external_customer_id, coupon_code)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Context**
Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete an applied coupon.

**Description**
This PR adds the destroy endpoint for applied coupon.