### PR TITLE
feat(instant_charge): Add API route to show a fee

### DIFF
--- a/lago_python_client/client.py
+++ b/lago_python_client/client.py
@@ -13,6 +13,7 @@ from .clients.subscription_client import SubscriptionClient
 from .clients.customer_client import CustomerClient
 from .clients.invoice_client import InvoiceClient
 from .clients.event_client import EventClient
+from .clients.fee_client import FeeClient
 from .clients.webhook_client import WebhookClient
 from .clients.wallet_client import WalletClient
 from .clients.wallet_transaction_client import WalletTransactionClient
@@ -39,6 +40,10 @@ class Client:
     @callable_cached_property
     def events(self) -> EventClient:
         return EventClient(self.base_api_url, self.api_key)
+
+    @callable_cached_property
+    def fees(self) -> FeeClient:
+        return FeeClient(self.base_api_url, self.api_key)
 
     @callable_cached_property
     def groups(self) -> GroupClient:

--- a/lago_python_client/clients/fee_client.py
+++ b/lago_python_client/clients/fee_client.py
@@ -1,0 +1,11 @@
+import requests
+from typing import Any, ClassVar, Type
+
+from pydantic import BaseModel
+from .base_client import BaseClient
+from lago_python_client.models.fee import FeeResponse
+
+class FeeClient(BaseClient):
+    API_RESOURCE: ClassVar[str] = 'fees'
+    RESPONSE_MODEL: ClassVar[Type[BaseModel]] = FeeResponse
+    ROOT_NAME: ClassVar[str] = 'fee'

--- a/lago_python_client/models/credit.py
+++ b/lago_python_client/models/credit.py
@@ -1,12 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List
 
-
-class InvoiceItemResponse(BaseModel):
-    lago_id: Optional[str]
-    type: Optional[str]
-    code: Optional[str]
-    name: Optional[str]
+from .invoice_item import InvoiceItemResponse
 
 
 class InvoiceShortDetails(BaseModel):

--- a/lago_python_client/models/fee.py
+++ b/lago_python_client/models/fee.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List
+from .invoice_item import InvoiceItemResponse
+
+class FeeResponse(BaseModel):
+    lago_id: Optional[str]
+    item: Optional[InvoiceItemResponse]
+    amount_cents: Optional[int]
+    amount_currency: Optional[str]
+    vat_amount_cents: Optional[int]
+    vat_amount_currency: Optional[str]
+    units: Optional[float]
+    events_count: Optional[int]
+
+class FeesResponse(BaseModel):
+    __root__: List[FeeResponse]

--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -3,6 +3,8 @@ from typing import Optional, List
 from .credit import CreditsResponse, InvoiceItemResponse
 from .customer import CustomerResponse
 from .subscription import SubscriptionsResponse
+from .fee import FeeResponse, FeesResponse
+from .invoice_item import InvoiceItemResponse
 
 
 # Deprecated: Will be removed in the future
@@ -23,21 +25,6 @@ class InvoiceMetadataList(BaseModel):
 class Invoice(BaseModel):
     payment_status: Optional[str]
     metadata: Optional[InvoiceMetadataList]
-
-
-class FeeResponse(BaseModel):
-    lago_id: Optional[str]
-    item: Optional[InvoiceItemResponse]
-    amount_cents: Optional[int]
-    amount_currency: Optional[str]
-    vat_amount_cents: Optional[int]
-    vat_amount_currency: Optional[str]
-    units: Optional[float]
-    events_count: Optional[int]
-
-
-class FeesResponse(BaseModel):
-    __root__: List[FeeResponse]
 
 
 class InvoiceResponse(BaseModel):

--- a/lago_python_client/models/invoice_item.py
+++ b/lago_python_client/models/invoice_item.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+class InvoiceItemResponse(BaseModel):
+    lago_id: Optional[str]
+    type: Optional[str]
+    code: Optional[str]
+    name: Optional[str]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,7 @@ from tests.test_plan_client import TestPlanClient
 from tests.test_add_on_client import TestAddOnClient
 from tests.test_organization_client import TestOrganizationClient
 from tests.test_invoice_client import TestInvoiceClient
+from tests.test_fee_client import TestFeeClient
 from tests.test_webhook_client import TestWebhookClient
 from tests.test_client import TestClient
 from tests.test_wallet_client import TestWalletClient

--- a/tests/fixtures/fee.json
+++ b/tests/fixtures/fee.json
@@ -1,0 +1,17 @@
+{
+  "fee": {
+    "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "lago_group_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+    "item": {
+      "type": "charge",
+      "code": "fee_code",
+      "name": "Fee Code"
+    },
+    "amount_cents": 120,
+    "amount_currency": "EUR",
+    "vat_amount_cents": 20,
+    "vat_amount_currency": "EUR",
+    "units": "10.0",
+    "events_count": 10
+  }
+}

--- a/tests/test_fee_client.py
+++ b/tests/test_fee_client.py
@@ -1,0 +1,24 @@
+import unittest
+import requests_mock
+import os
+
+from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
+
+def mock_response():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    my_data_path = os.path.join(this_dir, 'fixtures/fee.json')
+
+    with open(my_data_path, 'r') as fee_response:
+        return fee_response.read()
+
+class TestFeeClient(unittest.TestCase):
+  def test_valid_find_fee_request(self):
+    client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+    identifier = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+
+    with requests_mock.Mocker() as m:
+        m.register_uri('GET', 'https://api.getlago.com/api/v1/fees/' + identifier, text=mock_response())
+        response = client.fees().find(identifier)
+
+    self.assertEqual(response.lago_id, identifier)


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds a new route to retrieve a single fee via the API (`GET /api/v1/fees/:id`)

Related to https://github.com/getlago/lago-api/pull/866