### PR TITLE
Fix #73 Raise `LagoApiError` with `500` status code around `invalid json` or `empty data` cases

### DIFF
--- a/lago_python_client/clients/applied_coupon_client.py
+++ b/lago_python_client/clients/applied_coupon_client.py
@@ -6,6 +6,8 @@ from typing import Dict
 from urllib.parse import urljoin
 from requests import Response
 from ..services.json import from_json
+from ..services.response import verify_response
+
 
 class AppliedCouponClient(BaseClient):
     def api_resource(self):
@@ -22,6 +24,6 @@ class AppliedCouponClient(BaseClient):
         query_url = urljoin(self.base_url, api_resource)
 
         api_response = requests.delete(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response)).get(self.root_name())
+        data = from_json(verify_response(api_response)).get(self.root_name())
 
         return self.prepare_response(data)

--- a/lago_python_client/clients/base_client.py
+++ b/lago_python_client/clients/base_client.py
@@ -1,5 +1,3 @@
-from http import HTTPStatus
-import sys
 from typing import Any, Optional
 from urllib.parse import urljoin, urlencode
 
@@ -7,13 +5,9 @@ from pydantic import BaseModel
 import requests
 from requests import Response
 
-from lago_python_client.version import LAGO_VERSION
+from ..exceptions import LagoApiError
 from ..services.json import from_json, to_json
-
-if sys.version_info < (3, 9):
-    from typing import MutableMapping
-else:
-    from collections.abc import MutableMapping
+from ..version import LAGO_VERSION
 
 
 class BaseClient:
@@ -130,25 +124,3 @@ class BaseClient:
         }
 
         return response
-
-
-class LagoApiError(Exception):
-    def __init__(
-        self,
-        status_code: int,
-        url: Optional[str],
-        response: Any,
-        detail: Optional[str] = None,
-        headers: Optional[MutableMapping[str, str]] = None,
-    ) -> None:
-        if detail is None:
-            detail = HTTPStatus(status_code).phrase
-        self.status_code = status_code
-        self.url = url
-        self.response = response
-        self.detail = detail
-        self.headers = headers
-
-    def __repr__(self) -> str:
-        class_name = self.__class__.__name__
-        return f"{class_name}(status_code={self.status_code!r}, detail={self.detail!r})"

--- a/lago_python_client/clients/credit_note_client.py
+++ b/lago_python_client/clients/credit_note_client.py
@@ -6,6 +6,8 @@ from typing import Dict
 from urllib.parse import urljoin
 from requests import Response
 from ..services.json import from_json
+from ..services.response import verify_response
+
 
 class CreditNoteClient(BaseClient):
     def api_resource(self):
@@ -21,7 +23,7 @@ class CreditNoteClient(BaseClient):
         api_resource = self.api_resource() + '/' + resource_id + '/download'
         query_url = urljoin(self.base_url, api_resource)
         api_response = requests.post(query_url, headers=self.headers())
-        data = self.handle_response(api_response)
+        data = verify_response(api_response)
 
         if data is None:
             return True
@@ -32,6 +34,6 @@ class CreditNoteClient(BaseClient):
         api_resource = self.api_resource() + '/' + resource_id + '/void'
         query_url = urljoin(self.base_url, api_resource)
         api_response = requests.put(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response)).get(self.root_name())
+        data = from_json(verify_response(api_response)).get(self.root_name())
 
         return self.prepare_response(data)

--- a/lago_python_client/clients/customer_client.py
+++ b/lago_python_client/clients/customer_client.py
@@ -6,6 +6,7 @@ from lago_python_client.models.customer_usage import CustomerUsageResponse
 from typing import Dict
 from urllib.parse import urljoin
 from ..services.json import from_json
+from ..services.response import verify_response
 
 
 class CustomerClient(BaseClient):
@@ -23,6 +24,6 @@ class CustomerClient(BaseClient):
         query_url = urljoin(self.base_url, api_resource)
 
         api_response = requests.get(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response)).get('customer_usage')
+        data = from_json(verify_response(api_response)).get('customer_usage')
 
         return CustomerUsageResponse.parse_obj(data)

--- a/lago_python_client/clients/event_client.py
+++ b/lago_python_client/clients/event_client.py
@@ -7,6 +7,7 @@ from typing import Dict
 from pydantic import BaseModel
 from urllib.parse import urljoin
 from ..services.json import to_json
+from ..services.response import verify_response
 
 
 class EventClient(BaseClient):
@@ -24,7 +25,7 @@ class EventClient(BaseClient):
         }
         data = to_json(query_parameters)
         api_response = requests.post(query_url, data=data, headers=self.headers())
-        self.handle_response(api_response)
+        verify_response(api_response)
 
         return True
 

--- a/lago_python_client/clients/group_client.py
+++ b/lago_python_client/clients/group_client.py
@@ -5,6 +5,8 @@ from lago_python_client.models.group import GroupResponse
 from urllib.parse import urljoin, urlencode
 from requests import Response
 from ..services.json import from_json
+from ..services.response import verify_response
+
 
 class GroupClient(BaseClient):
     def api_resource(self):
@@ -24,6 +26,6 @@ class GroupClient(BaseClient):
 
         query_url = urljoin(self.base_url, api_resource)
         api_response = requests.get(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response))
+        data = from_json(verify_response(api_response))
 
         return self.prepare_index_response(data)

--- a/lago_python_client/clients/invoice_client.py
+++ b/lago_python_client/clients/invoice_client.py
@@ -6,6 +6,7 @@ from typing import Dict
 from urllib.parse import urljoin
 from requests import Response
 from ..services.json import from_json
+from ..services.response import verify_response
 
 
 class InvoiceClient(BaseClient):
@@ -22,7 +23,7 @@ class InvoiceClient(BaseClient):
         api_resource = self.api_resource() + '/' + resource_id + '/download'
         query_url = urljoin(self.base_url, api_resource)
         api_response = requests.post(query_url, headers=self.headers())
-        data = self.handle_response(api_response)
+        data = verify_response(api_response)
 
         if data is None:
             return True
@@ -33,7 +34,7 @@ class InvoiceClient(BaseClient):
         api_resource = self.api_resource() + '/' + resource_id + '/retry_payment'
         query_url = urljoin(self.base_url, api_resource)
         api_response = requests.post(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response)).get(self.root_name())
+        data = from_json(verify_response(api_response)).get(self.root_name())
 
         return self.prepare_response(data)
 
@@ -41,7 +42,7 @@ class InvoiceClient(BaseClient):
         api_resource = self.api_resource() + '/' + resource_id + '/refresh'
         query_url = urljoin(self.base_url, api_resource)
         api_response = requests.put(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response)).get(self.root_name())
+        data = from_json(verify_response(api_response)).get(self.root_name())
 
         return self.prepare_response(data)
 
@@ -49,6 +50,6 @@ class InvoiceClient(BaseClient):
         api_resource = self.api_resource() + '/' + resource_id + '/finalize'
         query_url = urljoin(self.base_url, api_resource)
         api_response = requests.put(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response)).get(self.root_name())
+        data = from_json(verify_response(api_response)).get(self.root_name())
 
         return self.prepare_response(data)

--- a/lago_python_client/clients/wallet_transaction_client.py
+++ b/lago_python_client/clients/wallet_transaction_client.py
@@ -6,6 +6,7 @@ from requests import Response
 from lago_python_client.models.wallet_transaction import WalletTransactionResponse
 from urllib.parse import urljoin, urlencode
 from ..services.json import from_json, to_json
+from ..services.response import verify_response
 
 
 class WalletTransactionClient(BaseClient):
@@ -22,7 +23,7 @@ class WalletTransactionClient(BaseClient):
         }
         data = to_json(query_parameters)
         api_response = requests.post(query_url, data=data, headers=self.headers())
-        data = self.handle_response(api_response)
+        data = verify_response(api_response)
 
         return self.prepare_response(from_json(data).get(self.root_name()))
 
@@ -34,7 +35,7 @@ class WalletTransactionClient(BaseClient):
 
         query_url = urljoin(self.base_url, api_resource)
         api_response = requests.get(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response))
+        data = from_json(verify_response(api_response))
 
         return self.prepare_index_response(data)
 

--- a/lago_python_client/clients/webhook_client.py
+++ b/lago_python_client/clients/webhook_client.py
@@ -4,6 +4,7 @@ import requests
 from urllib.parse import urljoin
 from .base_client import BaseClient
 from ..services.json import from_json
+from ..services.response import verify_response
 
 
 class WebhookClient(BaseClient):
@@ -14,6 +15,6 @@ class WebhookClient(BaseClient):
         query_url = urljoin(self.base_url, 'webhooks/json_public_key')
 
         api_response = requests.get(query_url, headers=self.headers())
-        data = from_json(self.handle_response(api_response)).get(self.root_name())
+        data = from_json(verify_response(api_response)).get(self.root_name())
 
         return base64.b64decode(data['public_key'])

--- a/lago_python_client/exceptions.py
+++ b/lago_python_client/exceptions.py
@@ -1,0 +1,30 @@
+from http import HTTPStatus
+import sys
+from typing import Any, Optional
+
+if sys.version_info < (3, 9):
+    from typing import MutableMapping
+else:
+    from collections.abc import MutableMapping
+
+
+class LagoApiError(Exception):
+    def __init__(
+        self,
+        status_code: int,
+        url: Optional[str],
+        response: Any,
+        detail: Optional[str] = None,
+        headers: Optional[MutableMapping[str, str]] = None,
+    ) -> None:
+        if detail is None:
+            detail = HTTPStatus(status_code).phrase
+        self.status_code = status_code
+        self.url = url
+        self.response = response
+        self.detail = detail
+        self.headers = headers
+
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        return f"{class_name}(status_code={self.status_code!r}, detail={self.detail!r})"

--- a/lago_python_client/services/response.py
+++ b/lago_python_client/services/response.py
@@ -1,0 +1,31 @@
+from typing import Any, Final, Optional, Sequence
+
+from requests import Response
+
+from ..exceptions import LagoApiError
+from ..services.json import from_json
+
+RESPONSE_SUCCESS_CODES: Final[Sequence[int]] = [200, 201, 202, 204]
+
+
+def verify_response(response: Response) -> Optional[Response]:
+    """Verify response. Return response on success. Raise exception otherwise."""
+    if response.status_code in RESPONSE_SUCCESS_CODES:
+        if response.content:
+            return response
+        else:
+            return None
+    else:
+        if response.content:
+            response_data: Any = from_json(response)
+            detail: Optional[str] = getattr(response_data, 'error', None)
+        else:
+            response_data = None
+            detail = None
+        raise LagoApiError(
+            status_code=response.status_code,
+            url=response.request.url,
+            response=response_data,
+            detail=detail,
+            headers=response.headers,
+        )

--- a/lago_python_client/services/response.py
+++ b/lago_python_client/services/response.py
@@ -27,11 +27,11 @@ def _is_content_exists(response: Response) -> bool:
 def verify_response(response: Response) -> Optional[Response]:
     """Verify response."""
     if not _is_status_code_successful(response):
-        response_data: Any
+        response_data: Any = from_json(response)
         raise LagoApiError(
             status_code=response.status_code,
             url=response.request.url,
-            response=(response_data := from_json(response)),
+            response=response_data,
             detail=getattr(response_data, 'error', None),
             headers=response.headers,
         )

--- a/lago_python_client/services/response.py
+++ b/lago_python_client/services/response.py
@@ -1,5 +1,9 @@
 from http import HTTPStatus
-from typing import Any, Final, Optional, Set
+from typing import Any, Optional, Set
+try:
+    from typing import Final
+except ImportError:  # Python 3.7
+    from typing_extensions import Final
 
 from requests import Response
 

--- a/tests/test_add_on_client.py
+++ b/tests/test_add_on_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import AddOn
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def add_on_object():

--- a/tests/test_applied_add_on_client.py
+++ b/tests/test_applied_add_on_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import AppliedAddOn
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def create_applied_add_on():

--- a/tests/test_applied_coupon_client.py
+++ b/tests/test_applied_coupon_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import AppliedCoupon
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def create_applied_coupon():

--- a/tests/test_billable_metric_client.py
+++ b/tests/test_billable_metric_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import BillableMetric, BillableMetricGroup
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def billable_metric_object():

--- a/tests/test_coupon_client.py
+++ b/tests/test_coupon_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import Coupon, LimitationConfiguration
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def coupon_object():

--- a/tests/test_credit_note_client.py
+++ b/tests/test_credit_note_client.py
@@ -3,9 +3,9 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models.invoice import FeeResponse
 from lago_python_client.models.credit_note import Item, Items, CreditNote, CreditNoteUpdate
-from lago_python_client.clients.base_client import LagoApiError
 
 def credit_note_object():
     item1 = Item(

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import Customer, CustomerBillingConfiguration
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def create_customer():

--- a/tests/test_event_client.py
+++ b/tests/test_event_client.py
@@ -3,9 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
-from lago_python_client.models import Event
-from lago_python_client.models import BatchEvent
-from lago_python_client.clients.base_client import LagoApiError
+from lago_python_client.exceptions import LagoApiError
+from lago_python_client.models.event import BatchEvent, Event
 
 
 def create_event():

--- a/tests/test_invoice_client.py
+++ b/tests/test_invoice_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import InvoicePaymentStatusChange
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def update_invoice_object():

--- a/tests/test_json_services.py
+++ b/tests/test_json_services.py
@@ -2,6 +2,7 @@ import unittest
 
 from requests import Response
 
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.services.json import from_json, to_json
 
 
@@ -21,12 +22,23 @@ class TestJSONServices(unittest.TestCase):
         json_requests_response._content_consumed = True
         json_requests_response._content = json_bytes
         json_requests_response.status_code = 200
+        # ... or None
+        json_none = None
+        # ... or something incorrect
+        json_string_shit_happens = b'{"abc'
 
         # When service is applied
         # Then service result is equal to given data.
         self.assertEqual(from_json(json_string), expected_data)
         self.assertEqual(from_json(json_bytes), expected_data)
         self.assertEqual(from_json(json_requests_response), expected_data)
+        # ... or raise exception
+        with self.assertRaises(LagoApiError) as cm:
+            from_json(json_none)
+        self.assertEqual(cm.exception.detail, 'Input must be bytes, bytearray, memoryview, or str')
+        with self.assertRaises(LagoApiError):
+            from_json(json_string_shit_happens)
+
 
     def test_to_json(self):
         """Serialize data to json string."""

--- a/tests/test_organization_client.py
+++ b/tests/test_organization_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import Organization, OrganizationBillingConfiguration
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def organization_object():

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import Plan, Charge, Charges
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def plan_object():

--- a/tests/test_response_services.py
+++ b/tests/test_response_services.py
@@ -1,0 +1,78 @@
+from copy import deepcopy
+import unittest
+
+from requests import Request, Response
+
+from lago_python_client.exceptions import LagoApiError
+from lago_python_client.services.response import RESPONSE_SUCCESS_CODES, _is_status_code_successful, _is_content_exists, verify_response
+
+
+class TestResponseServices(unittest.TestCase):
+    """Test response services."""
+
+    def test_success_status_codes_exists(self):
+        """Ensure ``RESPONSE_SUCCESS_CODES`` is set."""
+        self.assertTrue(len(RESPONSE_SUCCESS_CODES) >= 4)
+
+    def test_is_status_code_successful(self):
+        """Check status code is successful."""
+        # Given instanse of ``requests.Response`` class with successful status code
+        response = Response()
+        response._content_consumed = True
+        response._content = b'{"a":{"b":"c"}}'
+        response.status_code = 200
+        # ... and with error status code
+        response404 = deepcopy(response)
+        response404._content = b''
+        response404.status_code = 404
+
+        # When check helper function is applied
+        # Then verification passes.
+        self.assertEqual(_is_status_code_successful(response), True)
+        # ... or not
+        self.assertEqual(_is_status_code_successful(response404), False)
+
+    def test_is_content_exists(self):
+        """Check content exists."""
+        # Given instanse of ``requests.Response`` class with content
+        response = Response()
+        response._content_consumed = True
+        response._content = b'{"a":{"b":"c"}}'
+        response.status_code = 200
+        # ... and with empty content
+        response204 = deepcopy(response)
+        response204._content = b''
+        response204.status_code = 204
+
+        # When check helper function is applied
+        # Then verification passes.
+        self.assertEqual(_is_content_exists(response), True)
+        # ... or not
+        self.assertEqual(_is_content_exists(response204), False)
+
+    def test_verify_response(self):
+        """Verify response."""
+        # Given instanse of ``requests.Response`` class with successful status code and content
+        response = Response()
+        response._content_consumed = True
+        response._content = b'{"a":{"b":"c"}}'
+        response.status_code = 200
+        # ... and with successful status code and empty content
+        response204 = deepcopy(response)
+        response204._content = b''
+        response204.status_code = 204
+        # ... and with error status code
+        response404 = deepcopy(response)
+        response404.status_code = 404
+        response404.request = Request(url='')
+
+        # When service is applied
+        # Then
+        self.assertEqual(verify_response(response), response)
+        self.assertEqual(verify_response(response204), None)
+        with self.assertRaises(LagoApiError):
+            verify_response(response404)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import Subscription
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def create_subscription():

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import Wallet
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def wallet_object():

--- a/tests/test_wallet_transaction_client.py
+++ b/tests/test_wallet_transaction_client.py
@@ -3,8 +3,8 @@ import requests_mock
 import os
 
 from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import WalletTransaction
-from lago_python_client.clients.base_client import LagoApiError
 
 
 def wallet_transaction_object():

--- a/tests/test_webhook_client.py
+++ b/tests/test_webhook_client.py
@@ -3,7 +3,7 @@ import unittest
 import requests_mock
 
 from lago_python_client.client import Client
-from lago_python_client.clients.base_client import LagoApiError
+from lago_python_client.exceptions import LagoApiError
 
 
 def mock_response():


### PR DESCRIPTION
Main commit in this PR is here: https://github.com/getlago/lago-python-client/pull/79/commits/3449d040d5b0d89b4b8cbf8487f736eb4af51a17

First two commits are just small refactoring and two last commits small test compatibility fixes

- [x] add case: json service with `None`
- [x] add case: json service with invalid data
- [x] refactor `handle_response` method as service (includes 2 checks now)