### PR TITLE
Add `make_url` service

### DIFF
--- a/lago_python_client/clients/add_on_client.py
+++ b/lago_python_client/clients/add_on_client.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient

--- a/lago_python_client/clients/applied_add_on_client.py
+++ b/lago_python_client/clients/applied_add_on_client.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient

--- a/lago_python_client/clients/applied_coupon_client.py
+++ b/lago_python_client/clients/applied_coupon_client.py
@@ -1,12 +1,12 @@
 import requests
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient
 from lago_python_client.models.applied_coupon import AppliedCouponResponse
-from urllib.parse import urljoin
 from requests import Response
 from ..services.json import from_json
+from ..services.request import make_url
 from ..services.response import verify_response
 
 
@@ -16,9 +16,10 @@ class AppliedCouponClient(BaseClient):
     ROOT_NAME: ClassVar[str] = 'applied_coupon'
 
     def destroy(self, external_customer_id: str, applied_coupon_id: str):
-        uri: str = '/'.join(('customers', external_customer_id, self.API_RESOURCE, applied_coupon_id))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=('customers', external_customer_id, self.API_RESOURCE, applied_coupon_id),
+        )
         api_response = requests.delete(query_url, headers=self.headers())
         data = from_json(verify_response(api_response)).get(self.ROOT_NAME)
 

--- a/lago_python_client/clients/applied_coupon_client.py
+++ b/lago_python_client/clients/applied_coupon_client.py
@@ -17,7 +17,7 @@ class AppliedCouponClient(BaseClient):
 
     def destroy(self, external_customer_id: str, applied_coupon_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=('customers', external_customer_id, self.API_RESOURCE, applied_coupon_id),
         )
         api_response = requests.delete(query_url, headers=self.headers())

--- a/lago_python_client/clients/base_client.py
+++ b/lago_python_client/clients/base_client.py
@@ -41,7 +41,7 @@ class BaseClient(ABC):
 
     def find(self, resource_id: str, params: dict = {}):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id),
         )
         data = to_json(params) if params else None
@@ -53,7 +53,7 @@ class BaseClient(ABC):
 
     def find_all(self, options: dict = {}):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, ),
             query_pairs=options,
         )
@@ -64,7 +64,7 @@ class BaseClient(ABC):
 
     def destroy(self, resource_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id),
         )
         api_response = requests.delete(query_url, headers=self.headers())
@@ -74,7 +74,7 @@ class BaseClient(ABC):
 
     def create(self, input_object: BaseModel):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, ),
         )
         query_parameters = {
@@ -91,7 +91,7 @@ class BaseClient(ABC):
 
     def update(self, input_object: BaseModel, identifier: Optional[str] = None):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, identifier) if identifier else (self.API_RESOURCE, ),
         )
         query_parameters = {

--- a/lago_python_client/clients/billable_metric_client.py
+++ b/lago_python_client/clients/billable_metric_client.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient

--- a/lago_python_client/clients/coupon_client.py
+++ b/lago_python_client/clients/coupon_client.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient

--- a/lago_python_client/clients/credit_note_client.py
+++ b/lago_python_client/clients/credit_note_client.py
@@ -17,7 +17,7 @@ class CreditNoteClient(BaseClient):
 
     def download(self, resource_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'download'),
         )
         api_response = requests.post(query_url, headers=self.headers())
@@ -30,7 +30,7 @@ class CreditNoteClient(BaseClient):
 
     def void(self, resource_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'void'),
         )
         api_response = requests.put(query_url, headers=self.headers())

--- a/lago_python_client/clients/credit_note_client.py
+++ b/lago_python_client/clients/credit_note_client.py
@@ -1,12 +1,12 @@
 import requests
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient
 from lago_python_client.models.credit_note import CreditNoteResponse
-from urllib.parse import urljoin
 from requests import Response
 from ..services.json import from_json
+from ..services.request import make_url
 from ..services.response import verify_response
 
 
@@ -16,9 +16,10 @@ class CreditNoteClient(BaseClient):
     ROOT_NAME: ClassVar[str] = 'credit_note'
 
     def download(self, resource_id: str):
-        uri: str = '/'.join((self.API_RESOURCE, resource_id, 'download'))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, resource_id, 'download'),
+        )
         api_response = requests.post(query_url, headers=self.headers())
         data = verify_response(api_response)
 
@@ -28,9 +29,10 @@ class CreditNoteClient(BaseClient):
             return self.prepare_object_response(from_json(data).get(self.ROOT_NAME))
 
     def void(self, resource_id: str):
-        uri: str = '/'.join((self.API_RESOURCE, resource_id, 'void'))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, resource_id, 'void'),
+        )
         api_response = requests.put(query_url, headers=self.headers())
         data = from_json(verify_response(api_response)).get(self.ROOT_NAME)
 

--- a/lago_python_client/clients/customer_client.py
+++ b/lago_python_client/clients/customer_client.py
@@ -1,12 +1,12 @@
 import requests
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient
 from lago_python_client.models.customer import CustomerResponse
 from lago_python_client.models.customer_usage import CustomerUsageResponse
-from urllib.parse import urljoin, urlencode
 from ..services.json import from_json
+from ..services.request import make_url
 from ..services.response import verify_response
 
 
@@ -16,15 +16,13 @@ class CustomerClient(BaseClient):
     ROOT_NAME: ClassVar[str] = 'customer'
 
     def current_usage(self, resource_id: str, external_subscription_id: str):
-        options: Dict[str, Any] = {
-            'external_subscription_id': external_subscription_id,
-        }
-        uri: str = '{uri_path}{uri_query}'.format(
-            uri_path='/'.join((self.API_RESOURCE, resource_id, 'current_usage')),
-            uri_query=f'?{urlencode(options)}',
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, resource_id, 'current_usage'),
+            query_pairs={
+                'external_subscription_id': external_subscription_id,
+            },
         )
-        query_url: str = urljoin(self.base_url, uri)
-
         api_response = requests.get(query_url, headers=self.headers())
         data = from_json(verify_response(api_response)).get('customer_usage')
 

--- a/lago_python_client/clients/customer_client.py
+++ b/lago_python_client/clients/customer_client.py
@@ -17,7 +17,7 @@ class CustomerClient(BaseClient):
 
     def current_usage(self, resource_id: str, external_subscription_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'current_usage'),
             query_pairs={
                 'external_subscription_id': external_subscription_id,

--- a/lago_python_client/clients/event_client.py
+++ b/lago_python_client/clients/event_client.py
@@ -1,11 +1,12 @@
 import requests
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient
 from lago_python_client.models.event import EventResponse
 from urllib.parse import urljoin
 from ..services.json import to_json
+from ..services.request import make_url
 from ..services.response import verify_response
 
 
@@ -15,9 +16,10 @@ class EventClient(BaseClient):
     ROOT_NAME: ClassVar[str] = 'event'
 
     def batch_create(self, input_object: BaseModel):
-        uri: str = '/'.join((self.API_RESOURCE, 'batch'))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, 'batch'),
+        )
         query_parameters = {
             self.ROOT_NAME: input_object.dict()
         }

--- a/lago_python_client/clients/event_client.py
+++ b/lago_python_client/clients/event_client.py
@@ -17,7 +17,7 @@ class EventClient(BaseClient):
 
     def batch_create(self, input_object: BaseModel):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, 'batch'),
         )
         query_parameters = {

--- a/lago_python_client/clients/group_client.py
+++ b/lago_python_client/clients/group_client.py
@@ -1,12 +1,12 @@
 import requests
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient
 from lago_python_client.models.group import GroupResponse
-from urllib.parse import urljoin, urlencode
 from requests import Response
 from ..services.json import from_json
+from ..services.request import make_url
 from ..services.response import verify_response
 
 
@@ -16,12 +16,11 @@ class GroupClient(BaseClient):
     ROOT_NAME: ClassVar[str] = 'group'
 
     def find_all(self, metric_code: str, options: dict = {}):
-        uri: str = '{uri_path}{uri_query}'.format(
-            uri_path='/'.join(('billable_metrics', metric_code, self.API_RESOURCE)),
-            uri_query=f'?{urlencode(options)}' if options else '',
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=('billable_metrics', metric_code, self.API_RESOURCE),
+            query_pairs=options,
         )
-        query_url: str = urljoin(self.base_url, uri)
-
         api_response = requests.get(query_url, headers=self.headers())
         data = from_json(verify_response(api_response))
 

--- a/lago_python_client/clients/group_client.py
+++ b/lago_python_client/clients/group_client.py
@@ -17,7 +17,7 @@ class GroupClient(BaseClient):
 
     def find_all(self, metric_code: str, options: dict = {}):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=('billable_metrics', metric_code, self.API_RESOURCE),
             query_pairs=options,
         )

--- a/lago_python_client/clients/invoice_client.py
+++ b/lago_python_client/clients/invoice_client.py
@@ -1,12 +1,12 @@
 import requests
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient
 from lago_python_client.models.invoice import InvoiceResponse
-from urllib.parse import urljoin
 from requests import Response
 from ..services.json import from_json
+from ..services.request import make_url
 from ..services.response import verify_response
 
 
@@ -16,9 +16,10 @@ class InvoiceClient(BaseClient):
     ROOT_NAME: ClassVar[str] = 'invoice'
 
     def download(self, resource_id: str):
-        uri: str = '/'.join((self.API_RESOURCE, resource_id, 'download'))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, resource_id, 'download'),
+        )
         api_response = requests.post(query_url, headers=self.headers())
         data = verify_response(api_response)
 
@@ -28,27 +29,30 @@ class InvoiceClient(BaseClient):
             return self.prepare_object_response(from_json(data).get(self.ROOT_NAME))
 
     def retry_payment(self, resource_id: str):
-        uri: str = '/'.join((self.API_RESOURCE, resource_id, 'retry_payment'))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, resource_id, 'retry_payment'),
+        )
         api_response = requests.post(query_url, headers=self.headers())
         data = from_json(verify_response(api_response)).get(self.ROOT_NAME)
 
         return self.prepare_object_response(data)
 
     def refresh(self, resource_id: str):
-        uri: str = '/'.join((self.API_RESOURCE, resource_id, 'refresh'))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, resource_id, 'refresh'),
+        )
         api_response = requests.put(query_url, headers=self.headers())
         data = from_json(verify_response(api_response)).get(self.ROOT_NAME)
 
         return self.prepare_object_response(data)
 
     def finalize(self, resource_id: str):
-        uri: str = '/'.join((self.API_RESOURCE, resource_id, 'finalize'))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, resource_id, 'finalize'),
+        )
         api_response = requests.put(query_url, headers=self.headers())
         data = from_json(verify_response(api_response)).get(self.ROOT_NAME)
 

--- a/lago_python_client/clients/invoice_client.py
+++ b/lago_python_client/clients/invoice_client.py
@@ -17,7 +17,7 @@ class InvoiceClient(BaseClient):
 
     def download(self, resource_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'download'),
         )
         api_response = requests.post(query_url, headers=self.headers())
@@ -30,7 +30,7 @@ class InvoiceClient(BaseClient):
 
     def retry_payment(self, resource_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'retry_payment'),
         )
         api_response = requests.post(query_url, headers=self.headers())
@@ -40,7 +40,7 @@ class InvoiceClient(BaseClient):
 
     def refresh(self, resource_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'refresh'),
         )
         api_response = requests.put(query_url, headers=self.headers())
@@ -50,7 +50,7 @@ class InvoiceClient(BaseClient):
 
     def finalize(self, resource_id: str):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'finalize'),
         )
         api_response = requests.put(query_url, headers=self.headers())

--- a/lago_python_client/clients/organization_client.py
+++ b/lago_python_client/clients/organization_client.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient

--- a/lago_python_client/clients/plan_client.py
+++ b/lago_python_client/clients/plan_client.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient

--- a/lago_python_client/clients/subscription_client.py
+++ b/lago_python_client/clients/subscription_client.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient

--- a/lago_python_client/clients/wallet_client.py
+++ b/lago_python_client/clients/wallet_client.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Type
+from typing import ClassVar, Type
 
 from pydantic import BaseModel
 from .base_client import BaseClient

--- a/lago_python_client/clients/wallet_transaction_client.py
+++ b/lago_python_client/clients/wallet_transaction_client.py
@@ -17,7 +17,7 @@ class WalletTransactionClient(BaseClient):
 
     def create(self, input_object: BaseModel):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, ),
         )
         query_parameters = {
@@ -31,7 +31,7 @@ class WalletTransactionClient(BaseClient):
 
     def find_all(self, wallet_id: str, options: dict = {}):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=('wallets', wallet_id, self.API_RESOURCE),
             query_pairs=options,
         )

--- a/lago_python_client/clients/wallet_transaction_client.py
+++ b/lago_python_client/clients/wallet_transaction_client.py
@@ -5,8 +5,8 @@ from pydantic import BaseModel
 from .base_client import BaseClient
 from requests import Response
 from lago_python_client.models.wallet_transaction import WalletTransactionResponse
-from urllib.parse import urljoin, urlencode
 from ..services.json import from_json, to_json
+from ..services.request import make_url
 from ..services.response import verify_response
 
 
@@ -16,8 +16,10 @@ class WalletTransactionClient(BaseClient):
     ROOT_NAME: ClassVar[str] = 'wallet_transactions'
 
     def create(self, input_object: BaseModel):
-        query_url: str = urljoin(self.base_url, self.API_RESOURCE)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, ),
+        )
         query_parameters = {
             'wallet_transaction': input_object.dict()
         }
@@ -28,12 +30,11 @@ class WalletTransactionClient(BaseClient):
         return self.prepare_response(from_json(data).get(self.ROOT_NAME))
 
     def find_all(self, wallet_id: str, options: dict = {}):
-        uri: str = '{uri_path}{uri_query}'.format(
-            uri_path='/'.join(('wallets', wallet_id, self.API_RESOURCE)),
-            uri_query=f'?{urlencode(options)}' if options else '',
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=('wallets', wallet_id, self.API_RESOURCE),
+            query_pairs=options,
         )
-        query_url: str = urljoin(self.base_url, uri)
-
         api_response = requests.get(query_url, headers=self.headers())
         data = from_json(verify_response(api_response))
 

--- a/lago_python_client/clients/webhook_client.py
+++ b/lago_python_client/clients/webhook_client.py
@@ -3,9 +3,9 @@ import requests
 from typing import ClassVar, Type
 
 from pydantic import BaseModel
-from urllib.parse import urljoin
 from .base_client import BaseClient
 from ..services.json import from_json
+from ..services.request import make_url
 from ..services.response import verify_response
 
 
@@ -15,9 +15,10 @@ class WebhookClient(BaseClient):
     ROOT_NAME: ClassVar[str] = 'webhook'
 
     def public_key(self):
-        uri: str = '/'.join((self.API_RESOURCE, 'json_public_key'))
-        query_url: str = urljoin(self.base_url, uri)
-
+        query_url: str = make_url(
+            scheme_plus_authority=self.base_url,
+            path_parts=(self.API_RESOURCE, 'json_public_key'),
+        )
         api_response = requests.get(query_url, headers=self.headers())
         data = from_json(verify_response(api_response)).get(self.ROOT_NAME)
 

--- a/lago_python_client/clients/webhook_client.py
+++ b/lago_python_client/clients/webhook_client.py
@@ -16,7 +16,7 @@ class WebhookClient(BaseClient):
 
     def public_key(self):
         query_url: str = make_url(
-            scheme_plus_authority=self.base_url,
+            origin=self.base_url,
             path_parts=(self.API_RESOURCE, 'json_public_key'),
         )
         api_response = requests.get(query_url, headers=self.headers())

--- a/lago_python_client/services/request.py
+++ b/lago_python_client/services/request.py
@@ -1,5 +1,9 @@
-from typing import Dict, Final, Sequence
+from typing import Dict, Sequence
 from urllib.parse import urljoin, urlencode
+try:
+    from typing import Final
+except ImportError:  # Python 3.7
+    from typing_extensions import Final
 
 URI_TEMPLATE: Final[str] = '{uri_path}{uri_query}'
 QUERY_TEMPLATE: Final[str] = '?{query}'

--- a/lago_python_client/services/request.py
+++ b/lago_python_client/services/request.py
@@ -9,10 +9,10 @@ URI_TEMPLATE: Final[str] = '{uri_path}{uri_query}'
 QUERY_TEMPLATE: Final[str] = '?{query}'
 
 
-def make_url(*, scheme_plus_authority: str, path_parts: Sequence[str], query_pairs: Dict[str, str] = {}) -> str:
+def make_url(*, origin: str, path_parts: Sequence[str], query_pairs: Dict[str, str] = {}) -> str:
     """Return url."""
     return urljoin(
-        scheme_plus_authority,
+        origin,
         URI_TEMPLATE.format(
             uri_path='/'.join(path_parts),
             uri_query=QUERY_TEMPLATE.format(

--- a/lago_python_client/services/request.py
+++ b/lago_python_client/services/request.py
@@ -1,0 +1,18 @@
+from typing import Dict, Final, Sequence
+from urllib.parse import urljoin, urlencode
+
+URI_TEMPLATE: Final[str] = '{uri_path}{uri_query}'
+QUERY_TEMPLATE: Final[str] = '?{query}'
+
+
+def make_url(*, scheme_plus_authority: str, path_parts: Sequence[str], query_pairs: Dict[str, str] = {}) -> str:
+    """Return url."""
+    return urljoin(
+        scheme_plus_authority,
+        URI_TEMPLATE.format(
+            uri_path='/'.join(path_parts),
+            uri_query=QUERY_TEMPLATE.format(
+                query=urlencode(query_pairs),
+            ) if query_pairs else '',
+        ),
+    )

--- a/tests/test_request_services.py
+++ b/tests/test_request_services.py
@@ -1,0 +1,41 @@
+import unittest
+
+from lago_python_client.services.request import make_url
+
+
+class TestRequestServices(unittest.TestCase):
+    """Test request services."""
+
+    def test_make_url(self):
+        """Make url."""
+        # Given
+        api_url = 'https://api.getlago.com/api/v1/'
+        some_path_parts = ('team', 'anhtho', 'congratulate')
+        query_name_value = {
+            'message': "The future belongs to those who believe in the beauty of their dreams. Happy International Women's Day!",
+            'date': '08.03.2023',
+        }
+
+        # When service is applied
+        # Then
+        self.assertEqual(
+            make_url(scheme_plus_authority=api_url, path_parts=some_path_parts, query_pairs=query_name_value), 
+            'https://api.getlago.com/api/v1/team/anhtho/congratulate?message=The+future+belongs+to+those+who+believe+in+the+beauty+of+their+dreams.+Happy+International+Women%27s+Day%21&date=08.03.2023',
+        )
+
+    def test_make_url_no_query(self):
+        """Make url."""
+        # Given
+        api_url = 'https://api.getlago.com/api/v1/'
+        some_path_parts = ('hello', )
+
+        # When service is applied
+        # Then
+        self.assertEqual(
+            make_url(scheme_plus_authority=api_url, path_parts=some_path_parts), 
+            'https://api.getlago.com/api/v1/hello',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_request_services.py
+++ b/tests/test_request_services.py
@@ -24,7 +24,7 @@ class TestRequestServices(unittest.TestCase):
         )
 
     def test_make_url_no_query(self):
-        """Make url."""
+        """Make url without query name-value pairs."""
         # Given
         api_url = 'https://api.getlago.com/api/v1/'
         some_path_parts = ('hello', )

--- a/tests/test_request_services.py
+++ b/tests/test_request_services.py
@@ -19,7 +19,7 @@ class TestRequestServices(unittest.TestCase):
         # When service is applied
         # Then
         self.assertEqual(
-            make_url(scheme_plus_authority=api_url, path_parts=some_path_parts, query_pairs=query_name_value), 
+            make_url(origin=api_url, path_parts=some_path_parts, query_pairs=query_name_value), 
             'https://api.getlago.com/api/v1/team/anhtho/congratulate?message=The+future+belongs+to+those+who+believe+in+the+beauty+of+their+dreams.+Happy+International+Women%27s+Day%21&date=08.03.2023',
         )
 
@@ -32,7 +32,7 @@ class TestRequestServices(unittest.TestCase):
         # When service is applied
         # Then
         self.assertEqual(
-            make_url(scheme_plus_authority=api_url, path_parts=some_path_parts), 
+            make_url(origin=api_url, path_parts=some_path_parts), 
             'https://api.getlago.com/api/v1/hello',
         )
 


### PR DESCRIPTION
- [x] Add `make_url` service with tests
- - `make_url(*, origin: str, path_parts: Sequence[str], query_pairs: Dict[str, str] = {}) -> str
    Return url.`
- [x] Simplify `*Client` methods:
- - we call `make_url` service instead of repeating the same url construction code here and there (https://en.wikipedia.org/wiki/Single-responsibility_principle)
- - we make `*Client` methods looks closer to pipelines (which call services step by step and do nothing else https://returns.readthedocs.io/en/latest/pages/pipeline.html) 

Main commit for review is here: https://github.com/getlago/lago-python-client/pull/83/commits/434f59805a4cf20e9c71eef8e664b577683e5f75

URI scheme description: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
![uri](https://upload.wikimedia.org/wikipedia/commons/thumb/d/d6/URI_syntax_diagram.svg/2560px-URI_syntax_diagram.svg.png)
```
          userinfo       host      port
          ┌──┴───┐ ┌──────┴──────┐ ┌┴┐
  https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top
  └─┬─┘   └─────────────┬────────────┘└───────┬───────┘ └────────────┬────────────┘ └┬┘
  scheme          authority                  path                  query           fragment

```

P.S. Also this PR contain small congratulation with international woman's day :-) (hidden in tests)