### PR TITLE
Fix #86 Cache `*Client` instances

### DIFF
--- a/lago_python_client/client.py
+++ b/lago_python_client/client.py
@@ -1,20 +1,23 @@
-from lago_python_client.clients.applied_add_on_client import AppliedAddOnClient
-from lago_python_client.clients.applied_coupon_client import AppliedCouponClient
-from lago_python_client.clients.billable_metric_client import BillableMetricClient
-from lago_python_client.clients.coupon_client import CouponClient
-from lago_python_client.clients.group_client import GroupClient
-from lago_python_client.clients.credit_note_client import CreditNoteClient
-from lago_python_client.clients.plan_client import PlanClient
-from lago_python_client.clients.add_on_client import AddOnClient
-from lago_python_client.clients.organization_client import OrganizationClient
-from lago_python_client.clients.subscription_client import SubscriptionClient
-from lago_python_client.clients.customer_client import CustomerClient
-from lago_python_client.clients.invoice_client import InvoiceClient
-from lago_python_client.clients.event_client import EventClient
-from lago_python_client.clients.webhook_client import WebhookClient
-from lago_python_client.clients.wallet_client import WalletClient
-from lago_python_client.clients.wallet_transaction_client import WalletTransactionClient
 from urllib.parse import urljoin
+
+from .clients.applied_add_on_client import AppliedAddOnClient
+from .clients.applied_coupon_client import AppliedCouponClient
+from .clients.billable_metric_client import BillableMetricClient
+from .clients.coupon_client import CouponClient
+from .clients.group_client import GroupClient
+from .clients.credit_note_client import CreditNoteClient
+from .clients.plan_client import PlanClient
+from .clients.add_on_client import AddOnClient
+from .clients.organization_client import OrganizationClient
+from .clients.subscription_client import SubscriptionClient
+from .clients.customer_client import CustomerClient
+from .clients.invoice_client import InvoiceClient
+from .clients.event_client import EventClient
+from .clients.webhook_client import WebhookClient
+from .clients.wallet_client import WalletClient
+from .clients.wallet_transaction_client import WalletTransactionClient
+from .functools_ext import callable_cached_property
+
 try:
     from typing import Final
 except ImportError:  # Python 3.7
@@ -33,50 +36,66 @@ class Client:
     def base_api_url(self) -> str:
         return urljoin(self.api_url if self.api_url else Client.BASE_URL, Client.API_PATH)
 
+    @callable_cached_property
     def events(self) -> EventClient:
         return EventClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def groups(self) -> GroupClient:
         return GroupClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def subscriptions(self) -> SubscriptionClient:
         return SubscriptionClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def credit_notes(self) -> CreditNoteClient:
         return CreditNoteClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def customers(self) -> CustomerClient:
         return CustomerClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def invoices(self) -> InvoiceClient:
         return InvoiceClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def applied_coupons(self) -> AppliedCouponClient:
         return AppliedCouponClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def applied_add_ons(self) -> AppliedAddOnClient:
         return AppliedAddOnClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def billable_metrics(self) -> BillableMetricClient:
         return BillableMetricClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def coupons(self) -> CouponClient:
         return CouponClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def plans(self) -> PlanClient:
         return PlanClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def add_ons(self) -> AddOnClient:
         return AddOnClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def organizations(self) -> OrganizationClient:
         return OrganizationClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def webhooks(self) -> WebhookClient:
         return WebhookClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def wallets(self) -> WalletClient:
         return WalletClient(self.base_api_url, self.api_key)
 
+    @callable_cached_property
     def wallet_transactions(self) -> WalletTransactionClient:
         return WalletTransactionClient(self.base_api_url, self.api_key)

--- a/lago_python_client/client.py
+++ b/lago_python_client/client.py
@@ -15,66 +15,70 @@ from lago_python_client.clients.webhook_client import WebhookClient
 from lago_python_client.clients.wallet_client import WalletClient
 from lago_python_client.clients.wallet_transaction_client import WalletTransactionClient
 from urllib.parse import urljoin
+try:
+    from typing import Final
+except ImportError:  # Python 3.7
+    from typing_extensions import Final  # type: ignore
 
 
 class Client:
-    BASE_URL = 'https://api.getlago.com/'
-    API_PATH = 'api/v1/'
+    BASE_URL: Final[str] = 'https://api.getlago.com/'
+    API_PATH: Final[str] = 'api/v1/'
 
-    def __init__(self, api_key: str = '', api_url: str = ''):
-        self.api_key = api_key
-        self.api_url = api_url
+    def __init__(self, api_key: str = '', api_url: str = '') -> None:
+        self.api_key: str = api_key
+        self.api_url: str = api_url
 
-    def base_api_url(self):
+    def base_api_url(self) -> str:
         if self.api_url:
             return urljoin(self.api_url, Client.API_PATH)
         else:
             return urljoin(Client.BASE_URL, Client.API_PATH)
 
-    def events(self):
+    def events(self) -> EventClient:
         return EventClient(self.base_api_url(), self.api_key)
 
-    def groups(self):
+    def groups(self) -> GroupClient:
         return GroupClient(self.base_api_url(), self.api_key)
 
-    def subscriptions(self):
+    def subscriptions(self) -> SubscriptionClient:
         return SubscriptionClient(self.base_api_url(), self.api_key)
 
-    def credit_notes(self):
+    def credit_notes(self) -> CreditNoteClient:
         return CreditNoteClient(self.base_api_url(), self.api_key)
 
-    def customers(self):
+    def customers(self) -> CustomerClient:
         return CustomerClient(self.base_api_url(), self.api_key)
 
-    def invoices(self):
+    def invoices(self) -> InvoiceClient:
         return InvoiceClient(self.base_api_url(), self.api_key)
 
-    def applied_coupons(self):
+    def applied_coupons(self) -> AppliedCouponClient:
         return AppliedCouponClient(self.base_api_url(), self.api_key)
 
-    def applied_add_ons(self):
+    def applied_add_ons(self) -> AppliedAddOnClient:
         return AppliedAddOnClient(self.base_api_url(), self.api_key)
 
-    def billable_metrics(self):
+    def billable_metrics(self) -> BillableMetricClient:
         return BillableMetricClient(self.base_api_url(), self.api_key)
 
-    def coupons(self):
+    def coupons(self) -> CouponClient:
         return CouponClient(self.base_api_url(), self.api_key)
 
-    def plans(self):
+    def plans(self) -> PlanClient:
         return PlanClient(self.base_api_url(), self.api_key)
 
-    def add_ons(self):
+    def add_ons(self) -> AddOnClient:
         return AddOnClient(self.base_api_url(), self.api_key)
 
-    def organizations(self):
+    def organizations(self) -> OrganizationClient:
         return OrganizationClient(self.base_api_url(), self.api_key)
 
-    def webhooks(self):
+    def webhooks(self) -> WebhookClient:
         return WebhookClient(self.base_api_url(), self.api_key)
 
-    def wallets(self):
+    def wallets(self) -> WalletClient:
         return WalletClient(self.base_api_url(), self.api_key)
 
-    def wallet_transactions(self):
+    def wallet_transactions(self) -> WalletTransactionClient:
         return WalletTransactionClient(self.base_api_url(), self.api_key)

--- a/lago_python_client/client.py
+++ b/lago_python_client/client.py
@@ -29,56 +29,54 @@ class Client:
         self.api_key: str = api_key
         self.api_url: str = api_url
 
+    @property
     def base_api_url(self) -> str:
-        if self.api_url:
-            return urljoin(self.api_url, Client.API_PATH)
-        else:
-            return urljoin(Client.BASE_URL, Client.API_PATH)
+        return urljoin(self.api_url if self.api_url else Client.BASE_URL, Client.API_PATH)
 
     def events(self) -> EventClient:
-        return EventClient(self.base_api_url(), self.api_key)
+        return EventClient(self.base_api_url, self.api_key)
 
     def groups(self) -> GroupClient:
-        return GroupClient(self.base_api_url(), self.api_key)
+        return GroupClient(self.base_api_url, self.api_key)
 
     def subscriptions(self) -> SubscriptionClient:
-        return SubscriptionClient(self.base_api_url(), self.api_key)
+        return SubscriptionClient(self.base_api_url, self.api_key)
 
     def credit_notes(self) -> CreditNoteClient:
-        return CreditNoteClient(self.base_api_url(), self.api_key)
+        return CreditNoteClient(self.base_api_url, self.api_key)
 
     def customers(self) -> CustomerClient:
-        return CustomerClient(self.base_api_url(), self.api_key)
+        return CustomerClient(self.base_api_url, self.api_key)
 
     def invoices(self) -> InvoiceClient:
-        return InvoiceClient(self.base_api_url(), self.api_key)
+        return InvoiceClient(self.base_api_url, self.api_key)
 
     def applied_coupons(self) -> AppliedCouponClient:
-        return AppliedCouponClient(self.base_api_url(), self.api_key)
+        return AppliedCouponClient(self.base_api_url, self.api_key)
 
     def applied_add_ons(self) -> AppliedAddOnClient:
-        return AppliedAddOnClient(self.base_api_url(), self.api_key)
+        return AppliedAddOnClient(self.base_api_url, self.api_key)
 
     def billable_metrics(self) -> BillableMetricClient:
-        return BillableMetricClient(self.base_api_url(), self.api_key)
+        return BillableMetricClient(self.base_api_url, self.api_key)
 
     def coupons(self) -> CouponClient:
-        return CouponClient(self.base_api_url(), self.api_key)
+        return CouponClient(self.base_api_url, self.api_key)
 
     def plans(self) -> PlanClient:
-        return PlanClient(self.base_api_url(), self.api_key)
+        return PlanClient(self.base_api_url, self.api_key)
 
     def add_ons(self) -> AddOnClient:
-        return AddOnClient(self.base_api_url(), self.api_key)
+        return AddOnClient(self.base_api_url, self.api_key)
 
     def organizations(self) -> OrganizationClient:
-        return OrganizationClient(self.base_api_url(), self.api_key)
+        return OrganizationClient(self.base_api_url, self.api_key)
 
     def webhooks(self) -> WebhookClient:
-        return WebhookClient(self.base_api_url(), self.api_key)
+        return WebhookClient(self.base_api_url, self.api_key)
 
     def wallets(self) -> WalletClient:
-        return WalletClient(self.base_api_url(), self.api_key)
+        return WalletClient(self.base_api_url, self.api_key)
 
     def wallet_transactions(self) -> WalletTransactionClient:
-        return WalletTransactionClient(self.base_api_url(), self.api_key)
+        return WalletTransactionClient(self.base_api_url, self.api_key)

--- a/lago_python_client/functools_ext.py
+++ b/lago_python_client/functools_ext.py
@@ -1,6 +1,9 @@
-from functools import cached_property
 import sys
 from typing import Any, TypeVar
+try:
+    from functools import cached_property
+except ImportError:
+    cached_property = property
 try:
     from typing import ParamSpec
 except ImportError:  # Python 3.7, Python 3.8, Python 3.9

--- a/lago_python_client/functools_ext.py
+++ b/lago_python_client/functools_ext.py
@@ -1,0 +1,42 @@
+from functools import cached_property
+import sys
+from typing import Any, ParamSpec, TypeVar
+if sys.version_info >= (3, 9):
+    from collections.abc import Callable
+else:  # Python 3.7, Python 3.8
+    from typing import Callable
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class Proxy(object):
+    def __init__(self, _obj: object) -> None:
+        object.__setattr__(self, "_obj", _obj)
+
+    def __getattr__(self, name) -> Any:
+        if name == "_obj":
+            return object.__getattribute__(self, name)
+        return getattr(object.__getattribute__(self, "_obj"), name)
+
+    def __setattr__(self, name, value) -> None:
+        setattr(self._obj, name, value)
+
+    def __call__(self) -> Any:
+        return self._obj
+
+    def __repr__(self) -> str:
+        return repr(self._obj)
+
+    def __str__(self) -> str:
+        return str(self._obj)
+
+    def __format__(self, format_spec: str) -> str:
+        return format(self._obj, format_spec)
+
+    def __hash__(self) -> int:
+        return hash(self._obj)
+
+
+def callable_cached_property(func: Callable[P, T]) -> cached_property[T]:
+    return cached_property(lambda s: Proxy(func(s)))  # type: ignore

--- a/lago_python_client/functools_ext.py
+++ b/lago_python_client/functools_ext.py
@@ -1,6 +1,10 @@
 from functools import cached_property
 import sys
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, TypeVar
+try:
+    from typing import ParamSpec
+except ImportError:  # Python 3.7, Python 3.8, Python 3.9
+    from typing_extensions import ParamSpec  # type: ignore
 if sys.version_info >= (3, 9):
     from collections.abc import Callable
 else:  # Python 3.7, Python 3.8

--- a/lago_python_client/functools_ext.py
+++ b/lago_python_client/functools_ext.py
@@ -10,8 +10,6 @@ except ImportError:  # Python 3.7, Python 3.8, Python 3.9
     from typing_extensions import ParamSpec  # type: ignore
 if sys.version_info >= (3, 9):
     from collections.abc import Callable
-else:  # Python 3.7, Python 3.8
-    from typing import Callable
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -44,6 +42,9 @@ class Proxy(object):
     def __hash__(self) -> int:
         return hash(self._obj)
 
-
-def callable_cached_property(func: Callable[P, T]) -> cached_property[T]:
-    return cached_property(lambda s: Proxy(func(s)))  # type: ignore
+if sys.version_info >= (3, 9):
+    def callable_cached_property(func: Callable[P, T]) -> cached_property[T]:
+        return cached_property(lambda s: Proxy(func(s)))  # type: ignore
+else:
+    def callable_cached_property(func):  # type: ignore
+        return cached_property(lambda s: Proxy(func(s)))  # type: ignore

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,12 +8,12 @@ class TestClient(unittest.TestCase):
         client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d',
                         api_url='https://example.com/')
 
-        self.assertEqual(client.base_api_url(), 'https://example.com/api/v1/')
+        self.assertEqual(client.base_api_url, 'https://example.com/api/v1/')
 
     def test_base_url_when_api_url_is_not_given(self):
         client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
-        self.assertEqual(client.base_api_url(), 'https://api.getlago.com/api/v1/')
+        self.assertEqual(client.base_api_url, 'https://api.getlago.com/api/v1/')
 
 
 if __name__ == '__main__':

--- a/tests/test_functools_ext.py
+++ b/tests/test_functools_ext.py
@@ -1,0 +1,39 @@
+import unittest
+
+from lago_python_client.functools_ext import callable_cached_property
+
+
+class TestFunctoolsExt(unittest.TestCase):
+    def test_callable_cached_property(self):
+        # Given `InternalCollectionClient` class
+        class InternalCollectionClient:
+            def method(self) -> int:
+                return 1
+
+        # And `Client` class with `callable_cached_property` decorator on `collection` method
+        class Client:
+            @callable_cached_property
+            def collection(self) -> InternalCollectionClient:
+                return InternalCollectionClient()
+
+
+        # And `client` instance
+        client = Client()
+
+        # When we call collection as a method
+        method_result = client.collection().method()
+        # Or as a property
+        property_result = client.collection.method()
+
+        # Then both results are equal
+        self.assertEqual(property_result, method_result)
+        # And collection objects are stored in cache during first request
+        self.assertEqual(client.collection(), client.collection())
+        self.assertEqual(client.collection, client.collection)
+        # ... but only for same `Client` instance
+        self.assertNotEqual(Client().collection(), Client().collection())
+        self.assertNotEqual(Client().collection, Client().collection)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_functools_ext.py
+++ b/tests/test_functools_ext.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 from lago_python_client.functools_ext import callable_cached_property
@@ -27,12 +28,13 @@ class TestFunctoolsExt(unittest.TestCase):
 
         # Then both results are equal
         self.assertEqual(property_result, method_result)
-        # And collection objects are stored in cache during first request
-        self.assertEqual(client.collection(), client.collection())
-        self.assertEqual(client.collection, client.collection)
-        # ... but only for same `Client` instance
-        self.assertNotEqual(Client().collection(), Client().collection())
-        self.assertNotEqual(Client().collection, Client().collection)
+        if sys.version_info >= (3, 8):
+            # And collection objects are stored in cache during first request
+            self.assertEqual(client.collection(), client.collection())
+            self.assertEqual(client.collection, client.collection)
+            # ... but only for same `Client` instance
+            self.assertNotEqual(Client().collection(), Client().collection())
+            self.assertNotEqual(Client().collection, Client().collection)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Related issue: #86 

- [x] Cache `*Client` instances (Python 3.8+)
- [x] Add support to use `client.collection.method()` in additional to current default `client.collection().method()`

P.S. I suggest to make `client.collection.method()` default in docs. `()` usually means some action (and usually start from verb, not noun).

`.get_collection()` and `.collection` looks good but `.collection()` and `.get_collection` are not very beautiful.

(IMHO, may be it's just my perfectionism)

P.P.S. Also check Ruby client. Looks like it has similar problem (lack of cache)