### PR TITLE
feat(bm): Expose count of attached plans

### DIFF
--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -1,10 +1,11 @@
 from lago_python_client.models.applied_add_on import AppliedAddOn
 from lago_python_client.models.applied_coupon import AppliedCoupon
 from lago_python_client.models.billable_metric import BillableMetric, BillableMetricGroup
+from lago_python_client.models.charge import Charge, Charges, ChargesResponse
 from lago_python_client.models.coupon import Coupon, LimitationConfiguration
 from lago_python_client.models.credit import CreditResponse, CreditsResponse, InvoiceItemResponse
 from lago_python_client.models.credit_note import Item, Items, CreditNote, CreditNoteUpdate
-from lago_python_client.models.plan import Plan, Charges, Charge
+from lago_python_client.models.plan import Plan
 from lago_python_client.models.add_on import AddOn
 from lago_python_client.models.organization import Organization, OrganizationBillingConfiguration
 from lago_python_client.models.event import Event, BatchEvent

--- a/lago_python_client/models/billable_metric.py
+++ b/lago_python_client/models/billable_metric.py
@@ -24,3 +24,4 @@ class BillableMetricResponse(BaseModel):
     group: BillableMetricGroup
     active_subscriptions_count: int
     draft_invoices_count: int
+    plans_count: int

--- a/lago_python_client/models/charge.py
+++ b/lago_python_client/models/charge.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List
+
+class GroupProperties(BaseModel):
+    group_id: Optional[str]
+    values: Optional[dict]
+
+
+class Charge(BaseModel):
+    id: Optional[str]
+    billable_metric_id: Optional[str]
+    charge_model: Optional[str]
+    properties: Optional[dict]
+    group_properties: Optional[GroupProperties]
+
+class Charges(BaseModel):
+    __root__: List[Charge]
+
+class ChargeResponse(BaseModel):
+    lago_id: Optional[str]
+    lago_billable_metric_id: Optional[str]
+    billable_metric_code: Optional[str]
+    charge_model: Optional[str]
+    properties: Optional[dict]
+    group_properties: Optional[GroupProperties]
+
+class ChargesResponse(BaseModel):
+    __root__: List[ChargeResponse]

--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -1,19 +1,8 @@
 from pydantic import BaseModel, Field
 from typing import Optional, List, Union
 
-class GroupProperties(BaseModel):
-    group_id: Optional[str]
-    values: Optional[dict]
+from .charge import Charges, ChargesResponse
 
-class Charge(BaseModel):
-    id: Optional[str]
-    billable_metric_id: Optional[str]
-    charge_model: Optional[str]
-    properties: Optional[dict]
-    group_properties: Optional[GroupProperties]
-
-class Charges(BaseModel):
-    __root__: List[Charge]
 
 class Plan(BaseModel):
     name: Optional[str]
@@ -40,6 +29,6 @@ class PlanResponse(BaseModel):
     trial_period: Optional[float]
     pay_in_advance: Optional[bool]
     bill_charges_monthly: Optional[bool]
-    charges: Optional[Charges]
+    charges: Optional[ChargesResponse]
     active_subscriptions_count: int
     draft_invoices_count: int

--- a/tests/fixtures/billable_metric.json
+++ b/tests/fixtures/billable_metric.json
@@ -12,6 +12,7 @@
       "values": ["france", "italy", "spain"]
     },
     "active_subscriptions_count": 0,
-    "draft_invoices_count": 0
+    "draft_invoices_count": 0,
+    "plans_count": 0
   }
 }

--- a/tests/fixtures/billable_metric_index.json
+++ b/tests/fixtures/billable_metric_index.json
@@ -10,7 +10,8 @@
       "created_at": "2022-04-29T08:59:51Z",
       "group": {},
       "active_subscriptions_count": 0,
-      "draft_invoices_count": 0
+      "draft_invoices_count": 0,
+      "plans_count": 0
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314a11111",
@@ -22,7 +23,8 @@
       "created_at": "2022-04-30T08:59:51Z",
       "group": {},
       "active_subscriptions_count": 0,
-      "draft_invoices_count": 0
+      "draft_invoices_count": 0,
+      "plans_count": 0
     }
   ],
   "meta": {

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -17,6 +17,7 @@
       {
         "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
         "lago_billable_metric_id": "a6947936-628f-4945-8857-db6858ee7941",
+        "billable_metric_code": "bm_code",
         "created_at": "2022-07-01T14:47:14Z",
         "amount_currency": "EUR",
         "charge_model": "standard",

--- a/tests/fixtures/plan_index.json
+++ b/tests/fixtures/plan_index.json
@@ -18,6 +18,7 @@
         {
           "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
           "lago_billable_metric_id": "a6947936-628f-4945-8857-db6858ee7941",
+          "billable_metric_code": "bm_code",
           "created_at": "2022-07-01T14:47:14Z",
           "amount_currency": "EUR",
           "charge_model": "standard",
@@ -48,6 +49,7 @@
         {
           "lago_id": "dfdc725d-6341-4d61-831e-4ac9ccd509c0",
           "lago_billable_metric_id": "a6947936-628f-4945-8857-db6858ee7941",
+          "billable_metric_code": "bm_code",
           "created_at": "2022-07-01T12:45:33Z",
           "amount_currency": "EUR",
           "charge_model": "standard",


### PR DESCRIPTION
## Context

Plans edition has some issue if you update some properties of a billable metric, especially if you change groups definition or aggregation type :

"After the billable metric edition, new dimensions are created with new group_id that do not match the ones in the plans already defined"

## Description

This PR exposes a new `plans_count` field in the `BillableMetric` response type to let the API users know if the BM is editable.

Related to https://github.com/getlago/lago-api/pull/914
