### PR TITLE
Fix #97 - [Tests] Use pytest instead of unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install .
+          python -m pip install .[test]
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Run tests
         run: |
-          python3 -m unittest tests
+          python3 -m pytest "tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       - name: Run tests
         run: |
-          python3 -m pytest "tests"
+          python -m pytest "tests"

--- a/.github/workflows/pypi-push.yml
+++ b/.github/workflows/pypi-push.yml
@@ -20,12 +20,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install .
+          python -m pip install .[test]
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Run tests
         run: |
-          python3 -m unittest tests
+          python -m pytest "tests"
 
   publish:
     needs: build

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,9 @@ install_requires =
     pydantic
     requests-mock
 
+[options.extras_require]
+test =
+    pytest
+
 [options.package_data]
 * = py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,11 @@ install_requires =
     orjson
     requests~=2.28.2
     pydantic
-    requests-mock
 
 [options.extras_require]
 test =
     pytest
+    requests-mock
 
 [options.package_data]
 * = py.typed


### PR DESCRIPTION
- [x] Create `test` dependency group
- [x] Add `pytest` to `test` dependency group
- [x] Use `pytest` on CI 
- [x] Move `requests-mock` package to `test` dependencies group because of we do not need it in production...

You can keep working as usual and even use unittest tests if you like them more than pytest. Test refactoring is not required.

But if not, check pytest docs https://docs.pytest.org/en/7.2.x/ And may be you will find something useful for you.

For example, may be you will use `assert` instead of `self.assertEqual` and so on...


Related issue: #97 
