### PR TITLE
feat(instant_charge): Add API route to estimate instant fees amount

### DIFF
--- a/lago_python_client/clients/event_client.py
+++ b/lago_python_client/clients/event_client.py
@@ -1,14 +1,22 @@
-from typing import ClassVar, Optional, Type
+import sys
+from typing import Any, ClassVar, Optional, Type
 
 from pydantic import BaseModel
 
 from .base_client import BaseClient
+from .fee_client import FeeClient
 from ..mixins import CreateCommandMixin, FindCommandMixin
 from ..models.event import EventResponse
+from ..models.fee import FeeResponse
 from ..services.json import to_json
 from ..services.request import make_headers, make_url, send_post_request
-from ..services.response import verify_response, Response
+from ..services.response import get_response_data, prepare_object_list_response, verify_response, Response
 
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Mapping
+else:
+    from typing import Mapping
 
 class EventClient(
     CreateCommandMixin[EventResponse],
@@ -32,4 +40,22 @@ class EventClient(
         )
         verify_response(api_response)
 
-        return True  # TODO: should return None
+        return True # TODO: should return None
+
+    def estimate_fees(self, input_object: BaseModel) -> Mapping[str, Any]:
+        api_response: Response = send_post_request(
+            url= make_url(
+                origin=self.base_url,
+                path_parts=(self.API_RESOURCE, 'estimate_fees'),
+            ),
+            data=to_json({
+                self.ROOT_NAME: input_object.dict()
+            }),
+            headers=make_headers(api_key=self.api_key),
+        )
+
+        return prepare_object_list_response(
+            api_resource=FeeClient.API_RESOURCE,
+            response_model=FeeResponse,
+            data=get_response_data(response=api_response, key='fees'),
+        )

--- a/tests/fixtures/fees.json
+++ b/tests/fixtures/fees.json
@@ -1,0 +1,21 @@
+{
+  "fees": [
+    {
+      "lago_id": "nil",
+      "lago_group_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+      "item": {
+        "type": "instant_charge",
+        "code": "fee_code",
+        "name": "Fee Code"
+      },
+      "amount_cents": 120,
+      "amount_currency": "EUR",
+      "vat_amount_cents": 20,
+      "vat_amount_currency": "EUR",
+      "total_amount_cents": 140,
+      "total_amount_currency": "EUR",
+      "units": "1.0",
+      "events_count": 1
+    }
+  ]
+}


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds the new `POST api/v1/events/estimate_fees` route

Related to https://github.com/getlago/lago-api/pull/923
