### PR TITLE
Fix #91 - [Refactor] Add prepare response services (Part 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ This is a python wrapper for Lago API
 
 Install the lago-python-client via pip from PyPI:
 
-    $ pip install lago-python-client
+    $ python -m pip install "lago-python-client"
+
+(Alternative) Install the lago-python-client via [poetry](https://python-poetry.org/) from PyPI:
+
+    $ poetry add "lago-python-client"
 
 ## Usage
 
@@ -20,13 +24,13 @@ Check the [lago API reference](https://doc.getlago.com/docs/api/intro)
 ### Install the dependencies
 
 ```bash
-pip install .
+python -m pip install .[test]
 ```
 
 ### Run tests
 
 ```bash
-python3 -m unittest tests
+pytest
 ```
 
 ## Documentation

--- a/lago_python_client/clients/applied_coupon_client.py
+++ b/lago_python_client/clients/applied_coupon_client.py
@@ -6,9 +6,8 @@ from requests import Response
 
 from .base_client import BaseClient
 from ..models.applied_coupon import AppliedCouponResponse
-from ..services.json import from_json
 from ..services.request import make_url
-from ..services.response import prepare_object_response, verify_response
+from ..services.response import get_response_data, prepare_object_response
 
 
 class AppliedCouponClient(BaseClient):
@@ -25,5 +24,5 @@ class AppliedCouponClient(BaseClient):
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )

--- a/lago_python_client/clients/base_client.py
+++ b/lago_python_client/clients/base_client.py
@@ -95,7 +95,8 @@ class BaseClient(ABC):
         }
         api_response: Response = requests.post(query_url, data=to_json(query_parameters), headers=self.headers())
 
-        if not (response_data := get_response_data(response=api_response, key=self.ROOT_NAME)):
+        response_data = get_response_data(response=api_response, key=self.ROOT_NAME)
+        if not response_data:
             return True  # TODO: should return None
 
         return prepare_object_response(

--- a/lago_python_client/clients/base_client.py
+++ b/lago_python_client/clients/base_client.py
@@ -45,7 +45,7 @@ class BaseClient(ABC):
         """The resource key (required class property), used to access the response data."""
         raise NotImplementedError
 
-    def find(self, resource_id: str, params: dict = {}) -> BaseModel:
+    def find(self, resource_id: str, params: Mapping[str, str] = {}) -> BaseModel:
         query_url: str = make_url(
             origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id),
@@ -59,7 +59,7 @@ class BaseClient(ABC):
             data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
         )
 
-    def find_all(self, options: dict = {}) -> Mapping[str, Any]:
+    def find_all(self, options: Mapping[str, str] = {}) -> Mapping[str, Any]:
         query_url: str = make_url(
             origin=self.base_url,
             path_parts=(self.API_RESOURCE, ),

--- a/lago_python_client/clients/base_client.py
+++ b/lago_python_client/clients/base_client.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel
 import requests
 from requests import Response
 
-from ..services.json import from_json, to_json
+from ..services.json import to_json
 from ..services.request import make_url
-from ..services.response import prepare_index_response, prepare_object_response, verify_response
+from ..services.response import get_response_data, prepare_index_response, prepare_object_response
 from ..version import LAGO_VERSION
 
 if sys.version_info >= (3, 9):
@@ -24,21 +24,21 @@ class BaseClient(ABC):
         self.base_url = base_url
         self.api_key = api_key
 
-    @property  # type: ignore
+    @property
     @classmethod
     @abstractmethod
     def API_RESOURCE(cls) -> str:
         """Collection name (required class property) used to build query urls."""
         raise NotImplementedError
 
-    @property  # type: ignore
+    @property
     @classmethod
     @abstractmethod
     def RESPONSE_MODEL(cls) -> Type[BaseModel]:
         """Response model (required class property) used to prepare response."""
         raise NotImplementedError
 
-    @property  # type: ignore
+    @property
     @classmethod
     @abstractmethod
     def ROOT_NAME(cls) -> str:
@@ -56,7 +56,7 @@ class BaseClient(ABC):
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )
 
     def find_all(self, options: Mapping[str, str] = {}) -> Mapping[str, Any]:
@@ -70,7 +70,7 @@ class BaseClient(ABC):
         return prepare_index_response(
             api_resource=self.API_RESOURCE,
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)),
+            data=get_response_data(response=api_response),
         )
 
     def destroy(self, resource_id: str) -> BaseModel:
@@ -82,7 +82,7 @@ class BaseClient(ABC):
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )
 
     def create(self, input_object: BaseModel) -> Union[Optional[BaseModel], bool]:
@@ -94,14 +94,13 @@ class BaseClient(ABC):
             self.ROOT_NAME: input_object.dict()
         }
         api_response: Response = requests.post(query_url, data=to_json(query_parameters), headers=self.headers())
-        data = verify_response(api_response)
 
-        if data is None:
+        if not (response_data := get_response_data(response=api_response, key=self.ROOT_NAME)):
             return True  # TODO: should return None
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(data).get(self.ROOT_NAME),
+            data=response_data,
         )
 
     def update(self, input_object: BaseModel, identifier: Optional[str] = None) -> BaseModel:
@@ -117,7 +116,7 @@ class BaseClient(ABC):
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )
 
     def headers(self) -> Mapping[str, str]:

--- a/lago_python_client/clients/base_client.py
+++ b/lago_python_client/clients/base_client.py
@@ -85,7 +85,7 @@ class BaseClient(ABC):
             data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
         )
 
-    def create(self, input_object: BaseModel) -> Union[BaseModel, bool]:
+    def create(self, input_object: BaseModel) -> Union[Optional[BaseModel], bool]:
         query_url: str = make_url(
             origin=self.base_url,
             path_parts=(self.API_RESOURCE, ),
@@ -97,7 +97,7 @@ class BaseClient(ABC):
         data = verify_response(api_response)
 
         if data is None:
-            return True
+            return True  # TODO: should return None
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,

--- a/lago_python_client/clients/credit_note_client.py
+++ b/lago_python_client/clients/credit_note_client.py
@@ -1,5 +1,4 @@
 import requests
-import sys
 from typing import ClassVar, Optional, Type, Union
 
 from pydantic import BaseModel
@@ -7,9 +6,8 @@ from requests import Response
 
 from .base_client import BaseClient
 from ..models.credit_note import CreditNoteResponse
-from ..services.json import from_json
 from ..services.request import make_url
-from ..services.response import prepare_object_response, verify_response
+from ..services.response import get_response_data, prepare_object_response
 
 
 class CreditNoteClient(BaseClient):
@@ -23,14 +21,13 @@ class CreditNoteClient(BaseClient):
             path_parts=(self.API_RESOURCE, resource_id, 'download'),
         )
         api_response: Response = requests.post(query_url, headers=self.headers())
-        data = verify_response(api_response)
 
-        if data is None:
+        if not (response_data := get_response_data(response=api_response, key=self.ROOT_NAME)):
             return True  # TODO: should return None
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(data).get(self.ROOT_NAME),
+            data=response_data,
         )
 
     def void(self, resource_id: str) -> BaseModel:
@@ -42,5 +39,5 @@ class CreditNoteClient(BaseClient):
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )

--- a/lago_python_client/clients/credit_note_client.py
+++ b/lago_python_client/clients/credit_note_client.py
@@ -1,6 +1,6 @@
 import requests
 import sys
-from typing import ClassVar, Type, Union
+from typing import ClassVar, Optional, Type, Union
 
 from pydantic import BaseModel
 from requests import Response
@@ -17,7 +17,7 @@ class CreditNoteClient(BaseClient):
     RESPONSE_MODEL: ClassVar[Type[BaseModel]] = CreditNoteResponse
     ROOT_NAME: ClassVar[str] = 'credit_note'
 
-    def download(self, resource_id: str) -> Union[BaseModel, bool]:
+    def download(self, resource_id: str) -> Union[Optional[BaseModel], bool]:
         query_url: str = make_url(
             origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'download'),
@@ -26,7 +26,7 @@ class CreditNoteClient(BaseClient):
         data = verify_response(api_response)
 
         if data is None:
-            return True
+            return True  # TODO: should return None
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,

--- a/lago_python_client/clients/credit_note_client.py
+++ b/lago_python_client/clients/credit_note_client.py
@@ -22,7 +22,8 @@ class CreditNoteClient(BaseClient):
         )
         api_response: Response = requests.post(query_url, headers=self.headers())
 
-        if not (response_data := get_response_data(response=api_response, key=self.ROOT_NAME)):
+        response_data = get_response_data(response=api_response, key=self.ROOT_NAME)
+        if not response_data:
             return True  # TODO: should return None
 
         return prepare_object_response(

--- a/lago_python_client/clients/customer_client.py
+++ b/lago_python_client/clients/customer_client.py
@@ -7,9 +7,8 @@ from requests import Response
 from .base_client import BaseClient
 from ..models.customer import CustomerResponse
 from ..models.customer_usage import CustomerUsageResponse
-from ..services.json import from_json
 from ..services.request import make_url
-from ..services.response import prepare_object_response, verify_response
+from ..services.response import get_response_data, prepare_object_response
 
 
 class CustomerClient(BaseClient):
@@ -29,5 +28,5 @@ class CustomerClient(BaseClient):
 
         return prepare_object_response(
             response_model=CustomerUsageResponse,
-            data=from_json(verify_response(api_response)).get('customer_usage'),
+            data=get_response_data(response=api_response, key='customer_usage'),
         )

--- a/lago_python_client/clients/event_client.py
+++ b/lago_python_client/clients/event_client.py
@@ -1,5 +1,5 @@
 import requests
-from typing import ClassVar, Type
+from typing import ClassVar, Optional, Type
 
 from pydantic import BaseModel
 from requests import Response
@@ -16,7 +16,7 @@ class EventClient(BaseClient):
     RESPONSE_MODEL: ClassVar[Type[BaseModel]] = EventResponse
     ROOT_NAME: ClassVar[str] = 'event'
 
-    def batch_create(self, input_object: BaseModel) -> bool:
+    def batch_create(self, input_object: BaseModel) -> Optional[bool]:
         query_url: str = make_url(
             origin=self.base_url,
             path_parts=(self.API_RESOURCE, 'batch'),
@@ -28,4 +28,4 @@ class EventClient(BaseClient):
         api_response: Response = requests.post(query_url, data=data, headers=self.headers())
         verify_response(api_response)
 
-        return True
+        return True  # TODO: should return None

--- a/lago_python_client/clients/group_client.py
+++ b/lago_python_client/clients/group_client.py
@@ -22,7 +22,7 @@ class GroupClient(BaseClient):
     RESPONSE_MODEL: ClassVar[Type[BaseModel]] = GroupResponse
     ROOT_NAME: ClassVar[str] = 'group'
 
-    def find_all(self, metric_code: str, options: dict = {}) -> Mapping[str, Any]:
+    def find_all(self, metric_code: str, options: Mapping[str, str] = {}) -> Mapping[str, Any]:
         query_url: str = make_url(
             origin=self.base_url,
             path_parts=('billable_metrics', metric_code, self.API_RESOURCE),

--- a/lago_python_client/clients/group_client.py
+++ b/lago_python_client/clients/group_client.py
@@ -7,9 +7,8 @@ from requests import Response
 
 from .base_client import BaseClient
 from ..models.group import GroupResponse
-from ..services.json import from_json
 from ..services.request import make_url
-from ..services.response import prepare_index_response, verify_response
+from ..services.response import get_response_data, prepare_index_response
 
 if sys.version_info >= (3, 9):
     from collections.abc import Mapping
@@ -33,5 +32,5 @@ class GroupClient(BaseClient):
         return prepare_index_response(
             api_resource=self.API_RESOURCE,
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)),
+            data=get_response_data(response=api_response),
         )

--- a/lago_python_client/clients/invoice_client.py
+++ b/lago_python_client/clients/invoice_client.py
@@ -23,7 +23,8 @@ class InvoiceClient(BaseClient):
         )
         api_response: Response = requests.post(query_url, headers=self.headers())
 
-        if not (response_data := get_response_data(response=api_response, key=self.ROOT_NAME)):
+        response_data = get_response_data(response=api_response, key=self.ROOT_NAME)
+        if not response_data:
             return True  # TODO: should return None
 
         return prepare_object_response(

--- a/lago_python_client/clients/invoice_client.py
+++ b/lago_python_client/clients/invoice_client.py
@@ -1,5 +1,5 @@
 import requests
-from typing import ClassVar, Type, Union
+from typing import ClassVar, Optional, Type, Union
 
 from pydantic import BaseModel
 from requests import Response
@@ -16,7 +16,7 @@ class InvoiceClient(BaseClient):
     RESPONSE_MODEL: ClassVar[Type[BaseModel]] = InvoiceResponse
     ROOT_NAME: ClassVar[str] = 'invoice'
 
-    def download(self, resource_id: str) -> Union[BaseModel, bool]:
+    def download(self, resource_id: str) -> Union[Optional[BaseModel], bool]:
         query_url: str = make_url(
             origin=self.base_url,
             path_parts=(self.API_RESOURCE, resource_id, 'download'),
@@ -25,7 +25,7 @@ class InvoiceClient(BaseClient):
         data = verify_response(api_response)
 
         if data is None:
-            return True
+            return True  # TODO: should return None
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,

--- a/lago_python_client/clients/invoice_client.py
+++ b/lago_python_client/clients/invoice_client.py
@@ -1,4 +1,5 @@
 import requests
+import sys
 from typing import ClassVar, Optional, Type, Union
 
 from pydantic import BaseModel
@@ -6,9 +7,8 @@ from requests import Response
 
 from .base_client import BaseClient
 from ..models.invoice import InvoiceResponse
-from ..services.json import from_json
 from ..services.request import make_url
-from ..services.response import prepare_object_response, verify_response
+from ..services.response import get_response_data, prepare_object_response
 
 
 class InvoiceClient(BaseClient):
@@ -22,14 +22,13 @@ class InvoiceClient(BaseClient):
             path_parts=(self.API_RESOURCE, resource_id, 'download'),
         )
         api_response: Response = requests.post(query_url, headers=self.headers())
-        data = verify_response(api_response)
 
-        if data is None:
+        if not (response_data := get_response_data(response=api_response, key=self.ROOT_NAME)):
             return True  # TODO: should return None
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(data).get(self.ROOT_NAME),
+            data=response_data,
         )
 
     def retry_payment(self, resource_id: str) -> BaseModel:
@@ -41,7 +40,7 @@ class InvoiceClient(BaseClient):
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )
 
     def refresh(self, resource_id: str) -> BaseModel:
@@ -53,7 +52,7 @@ class InvoiceClient(BaseClient):
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )
 
     def finalize(self, resource_id: str) -> BaseModel:
@@ -65,5 +64,5 @@ class InvoiceClient(BaseClient):
 
         return prepare_object_response(
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )

--- a/lago_python_client/clients/wallet_transaction_client.py
+++ b/lago_python_client/clients/wallet_transaction_client.py
@@ -7,9 +7,9 @@ from requests import Response
 
 from .base_client import BaseClient
 from ..models.wallet_transaction import WalletTransactionResponse
-from ..services.json import from_json, to_json
+from ..services.json import to_json
 from ..services.request import make_url
-from ..services.response import prepare_create_response, prepare_index_response, verify_response
+from ..services.response import get_response_data, prepare_create_response, prepare_index_response
 
 if sys.version_info >= (3, 9):
     from collections.abc import Mapping
@@ -36,7 +36,7 @@ class WalletTransactionClient(BaseClient):
         return prepare_create_response(
             api_resource=self.API_RESOURCE,
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
+            data=get_response_data(response=api_response, key=self.ROOT_NAME),
         )
 
     def find_all(self, wallet_id: str, options: Mapping[str, str] = {}) -> Mapping[str, Any]:
@@ -50,5 +50,5 @@ class WalletTransactionClient(BaseClient):
         return prepare_index_response(
             api_resource=self.API_RESOURCE,
             response_model=self.RESPONSE_MODEL,
-            data=from_json(verify_response(api_response)),
+            data=get_response_data(response=api_response),
         )

--- a/lago_python_client/clients/wallet_transaction_client.py
+++ b/lago_python_client/clients/wallet_transaction_client.py
@@ -39,7 +39,7 @@ class WalletTransactionClient(BaseClient):
             data=from_json(verify_response(api_response)).get(self.ROOT_NAME),
         )
 
-    def find_all(self, wallet_id: str, options: dict = {}) -> Mapping[str, Any]:
+    def find_all(self, wallet_id: str, options: Mapping[str, str] = {}) -> Mapping[str, Any]:
         query_url: str = make_url(
             origin=self.base_url,
             path_parts=('wallets', wallet_id, self.API_RESOURCE),

--- a/lago_python_client/clients/webhook_client.py
+++ b/lago_python_client/clients/webhook_client.py
@@ -1,14 +1,32 @@
 import base64
-import requests
-from typing import ClassVar, Type
+from http import HTTPStatus
+import sys
+from typing import Any, ClassVar, Optional, Type, Union
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict
 
 from pydantic import BaseModel
+import requests
 from requests import Response
+import typeguard
 
 from .base_client import BaseClient
-from ..services.json import from_json
+from ..exceptions import LagoApiError
 from ..services.request import make_url
-from ..services.response import verify_response
+from ..services.response import get_response_data
+
+if sys.version_info >= (3, 9):
+    from collections.abc import Mapping, Sequence
+else:
+    from typing import Mapping, Sequence
+
+typeguard.config.collection_check_strategy = typeguard.CollectionCheckStrategy.ALL_ITEMS
+
+
+class _ResponseWithPublicKeyInside(TypedDict):
+    public_key: str
 
 
 class WebhookClient(BaseClient):
@@ -22,6 +40,17 @@ class WebhookClient(BaseClient):
             path_parts=(self.API_RESOURCE, 'json_public_key'),
         )
         api_response: Response = requests.get(query_url, headers=self.headers())
-        data = from_json(verify_response(api_response)).get(self.ROOT_NAME)
+        response_data: Optional[Union[Mapping[str, Any], Sequence[Any]]] = get_response_data(response=api_response, key=self.ROOT_NAME)
 
-        return base64.b64decode(data['public_key'])
+        try:
+            checked_response_data: _ResponseWithPublicKeyInside = typeguard.check_type(response_data, _ResponseWithPublicKeyInside)
+        except typeguard.TypeCheckError:
+            raise LagoApiError(
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,  # 500
+                url=None,
+                response=None,
+                detail='Incorrect response data',
+                headers=None,
+            )
+
+        return base64.b64decode(checked_response_data['public_key'])

--- a/lago_python_client/functools_ext.py
+++ b/lago_python_client/functools_ext.py
@@ -7,7 +7,7 @@ except ImportError:
 try:
     from typing import ParamSpec
 except ImportError:  # Python 3.7, Python 3.8, Python 3.9
-    from typing_extensions import ParamSpec  # type: ignore
+    from typing_extensions import ParamSpec
 if sys.version_info >= (3, 9):
     from collections.abc import Callable
 

--- a/lago_python_client/services/json.py
+++ b/lago_python_client/services/json.py
@@ -1,5 +1,6 @@
 from datetime import datetime, date, time
 from http import HTTPStatus
+import sys
 from typing import Any, Dict, List, NoReturn, Tuple, Union
 from uuid import UUID
 
@@ -9,9 +10,14 @@ from requests import Response
 
 from ..exceptions import LagoApiError
 
-Serializable = Union[str, Dict[Any, Any], List[Any], Tuple[Any], int, float, bool, datetime, date, time, UUID, None]  # And dataclass, TypedDict and ndarray
+if sys.version_info >= (3, 9):
+    from collections.abc import Mapping, Sequence
+else:
+    from typing import Mapping, Sequence
+
+Serializable = Union[str, Mapping[Any, Any], Sequence[Any], Tuple[Any], int, float, bool, datetime, date, time, UUID, None]  # And dataclass, TypedDict and ndarray
 Deserializable = Union[bytes, bytearray, memoryview, str]
-DeserializedData = Union[Dict[str, Any], List[Any], int, float, str, bool, None]
+DeserializedData = Union[Mapping[str, Any], Sequence[Any], int, float, str, bool, None]
 
 
 def to_json(data_container: Serializable) -> str:

--- a/lago_python_client/services/json.py
+++ b/lago_python_client/services/json.py
@@ -25,13 +25,13 @@ def to_json(data_container: Serializable) -> str:
     return orjson.dumps(data_container, option=orjson.OPT_NON_STR_KEYS).decode('utf-8')
 
 
-@typeclass
+@typeclass  # type: ignore
 def from_json(json_container) -> DeserializedData:
     """Deserialize data from json format."""
     raise TypeError('Type {0} is not supported'.format(type(json_container)))
 
 
-@from_json.instance(bytes)
+@from_json.instance(bytes)  # type: ignore
 @from_json.instance(bytearray)
 @from_json.instance(memoryview)
 @from_json.instance(str)
@@ -49,7 +49,7 @@ def _from_json_default(json_container: Deserializable) -> DeserializedData:
         )
 
 
-@from_json.instance(None)
+@from_json.instance(None)  # type: ignore
 def _from_json_none(json_container: None) -> NoReturn:
     """Deserialize json from ``None``."""
     raise LagoApiError(
@@ -61,7 +61,7 @@ def _from_json_none(json_container: None) -> NoReturn:
     )
 
 
-@from_json.instance(Response)
+@from_json.instance(Response)  # type: ignore
 def _from_json_requests_response_bytes(json_container: Response) -> DeserializedData:
     """Deserialize json from ``requests.Response`` class instances (from content bytes)."""
-    return from_json(json_container.content)
+    return from_json(json_container.content)  # type: ignore

--- a/lago_python_client/services/response.py
+++ b/lago_python_client/services/response.py
@@ -113,7 +113,7 @@ def prepare_index_response(api_resource: str, response_model: Type[BaseModel], d
 
     try:
         response_data: Mapping[str, _MappingOrSequence] = typeguard.check_type(data, Mapping[str, _MappingOrSequence])
-    except TypeCheckError as exc:
+    except typeguard.TypeCheckError as exc:
         raise LagoApiError(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,  # 500
             url=None,

--- a/lago_python_client/services/response.py
+++ b/lago_python_client/services/response.py
@@ -53,12 +53,12 @@ def verify_response(response: Response) -> Optional[Response]:
     return response
 
 
-def prepare_object_response(response_model: Type[BaseModel], data: Mapping[Any, Any]) -> BaseModel:
+def prepare_object_response(response_model: Type[BaseModel], data: Mapping[object, object]) -> BaseModel:
     """Return single object response - Pydantic model instance with provided data."""
     return response_model.parse_obj(data)
 
 
-def prepare_index_response(api_resource: str, response_model: Type[BaseModel], data: Mapping[str, Any]) -> Mapping[str, Any]:
+def prepare_index_response(api_resource: str, response_model: Type[BaseModel], data: Mapping[str, Sequence[Mapping[object, object]]]) -> Mapping[str, Any]:
     """Return index response with meta based on mapping data object."""
     return {
         api_resource: [
@@ -69,7 +69,7 @@ def prepare_index_response(api_resource: str, response_model: Type[BaseModel], d
     }
 
 
-def prepare_create_response(api_resource: str, response_model: Type[BaseModel], data: Sequence[Mapping[Any, Any]]) -> Mapping[str, Any]:
+def prepare_create_response(api_resource: str, response_model: Type[BaseModel], data: Sequence[Mapping[object, object]]) -> Mapping[str, Any]:
     """Return response based on sequence of data objects."""
     # The only usage - ``WalletTransactionClient.create``
     return {

--- a/lago_python_client/services/response.py
+++ b/lago_python_client/services/response.py
@@ -51,7 +51,7 @@ def _is_content_exists(response: Response) -> bool:
 def verify_response(response: Response) -> Optional[Response]:
     """Verify response."""
     if not _is_status_code_successful(response):
-        response_data: Any = from_json(response)
+        response_data: Any = from_json(response)  # type: ignore
         raise LagoApiError(
             status_code=response.status_code,
             url=response.request.url,
@@ -71,7 +71,7 @@ def get_response_data(*, response: Response, key: str = '') -> Optional[_Mapping
     response_or_None: Optional[Response] = verify_response(response)
     if not response_or_None:
         return None
-    deserialized_data: DeserializedData = from_json(response_or_None)
+    deserialized_data: DeserializedData = from_json(response_or_None)  # type: ignore
 
     # Ensure deserialized_data has correct type: sequence or mapping or raise LagoApiError
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     orjson
     requests~=2.28.2
     pydantic
-    typeguard
+    typeguard~=3.0.1
 
 [options.extras_require]
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,11 @@ install_requires =
     orjson
     requests~=2.28.2
     pydantic
+    typeguard
 
 [options.extras_require]
 test =
+    mypy==0.971
     pytest
     requests-mock
 


### PR DESCRIPTION
Related issues: #91 

- Add `get_response_data` service (with tests)
- Update `README.md`
- Install `typeguard` (https://typeguard.readthedocs.io/en/latest/index.html)
- Install (dev dependency) `mypy` (https://www.mypy-lang.org/)
- Use `typeguard` to check types in existed prepare response services

