### PR TITLE
feat(instant_charge): Expose fees updapte and get all routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Check the [lago API reference](https://doc.getlago.com/docs/api/intro)
 ### Install the dependencies
 
 ```bash
+python -m pip install --upgrade pip setuptools wheel
 python -m pip install .[test]
 ```
 

--- a/lago_python_client/clients/fee_client.py
+++ b/lago_python_client/clients/fee_client.py
@@ -1,12 +1,14 @@
 from typing import ClassVar, Type
 
 from .base_client import BaseClient
-from ..mixins import FindCommandMixin
+from ..mixins import FindCommandMixin, FindAllCommandMixin, UpdateCommandMixin
 from ..models.fee import FeeResponse
 
 
 class FeeClient(
     FindCommandMixin[FeeResponse],
+    FindAllCommandMixin[FeeResponse],
+    UpdateCommandMixin[FeeResponse],
     BaseClient,
 ):
     API_RESOURCE: ClassVar[str] = 'fees'

--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -9,6 +9,7 @@ from .plan import Plan
 from .add_on import AddOn
 from .organization import Organization, OrganizationBillingConfiguration
 from .event import Event, BatchEvent
+from .fee import Fee
 from .customer import Customer, CustomerBillingConfiguration, Metadata, MetadataList
 from .invoice import InvoicePaymentStatusChange, Invoice, InvoiceMetadata, InvoiceMetadataList
 from .invoice_item import InvoiceItemResponse

--- a/lago_python_client/models/fee.py
+++ b/lago_python_client/models/fee.py
@@ -1,12 +1,16 @@
 from typing import List, Optional
 
 from .invoice_item import InvoiceItemResponse
-from ..base_model import BaseResponseModel
+from ..base_model import BaseModel, BaseResponseModel
 
+class Fee(BaseModel):
+    payment_status: Optional[str]
 
 class FeeResponse(BaseResponseModel):
     lago_id: Optional[str]
-    item: Optional[InvoiceItemResponse]
+    lago_group_id: Optional[str]
+    lago_invoice_id: Optional[str]
+    external_subscription_id: Optional[str]
     amount_cents: Optional[int]
     amount_currency: Optional[str]
     vat_amount_cents: Optional[int]
@@ -15,6 +19,13 @@ class FeeResponse(BaseResponseModel):
     total_amount_currency: Optional[str]
     units: Optional[float]
     events_count: Optional[int]
+    payment_status: Optional[str]
+    created_at: Optional[str]
+    succeeded_at: Optional[str]
+    failed_at: Optional[str]
+    refunded_at: Optional[str]
+
+    item: Optional[InvoiceItemResponse]
 
 
 class FeesResponse(BaseResponseModel):

--- a/lago_python_client/models/invoice_item.py
+++ b/lago_python_client/models/invoice_item.py
@@ -4,7 +4,8 @@ from ..base_model import BaseResponseModel
 
 
 class InvoiceItemResponse(BaseResponseModel):
-    lago_id: Optional[str]
     type: Optional[str]
     code: Optional[str]
     name: Optional[str]
+    lago_item_id: Optional[str]
+    item_type: Optional[str]


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds:
- Definition for `GET /api/v1/fees`
- Definition for `PUT /api/v1/fees/:id`
- Add new fields definition to fees:
  - lago_invoice_id
  - external_subscription_id
  - payment_status
  - created_at
  - succeeded_at
  - failed_at
  - refunded_at
  - item[lago_item_id]
  - item[item_type]