### PR TITLE
Add PendingDeprecation warnings if someone uses `client.tag().operation()` instead of `client.tag.operation()`

### DIFF
--- a/lago_python_client/functools_ext.py
+++ b/lago_python_client/functools_ext.py
@@ -1,5 +1,6 @@
 import sys
 from typing import Any, TypeVar
+import warnings
 try:
     from functools import cached_property
 except ImportError:
@@ -28,6 +29,14 @@ class Proxy(object):
         setattr(self._obj, name, value)
 
     def __call__(self) -> Any:
+        warnings.warn(
+            ''.join((
+                'We are going to deprecate callable properties (`client.<your_tag_name>()`) in future. ',
+                'Please, remove braces. ',
+                'Use `client.<your_tag_name>.<your_operation_name>(...)` instead of `client.<your_tag_name>().<your_operation_name>(...)`',
+            )),
+            PendingDeprecationWarning,
+        )
         return self._obj
 
     def __repr__(self) -> str:


### PR DESCRIPTION
We show here that `client.tag.operation()` is preferred way over `client.tag().operation()`.

### Motivation
```

➜  lago-python-client git:(main) python3
Python 3.11.2 (main, Feb 16 2023, 03:07:35) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import this
The Zen of Python, by Tim Peters

Beautiful is better than ugly.
Explicit is better than implicit.
Simple is better than complex.
Complex is better than complicated.
Flat is better than nested.
Sparse is better than dense.
Readability counts.
Special cases aren't special enough to break the rules.
Although practicality beats purity.
Errors should never pass silently.
Unless explicitly silenced.
In the face of ambiguity, refuse the temptation to guess.
There should be one-- and preferably only one --obvious way to do it.  <------- Motivation
Although that way may not be obvious at first unless you're Dutch.
Now is better than never.
Although never is often better than *right* now.
If the implementation is hard to explain, it's a bad idea.
If the implementation is easy to explain, it may be a good idea.
Namespaces are one honking great idea -- let's do more of those!
>>>
```

### Info about warnings in Python (for Ruby/JS developers)

`PendingDeprecationWarning` warnings in Python are hidden by default. `Pytest` shows them if you'll run tests. But for end users they are visible if they run `python` with `-Wa` (rare cases, mostly only perfectionists will do it).

So it's not yet deprecation, it's "preparation for deprecation". It's like demonstration of intentions.

Later `PendingDeprecationWarning` warnings can be replaced to `DeprecationWarning` warnings with addition of deprecation date and will be visible for users. (It's warnings, not errors, they can be ignored.)
