### PR TITLE
Fix pytest warnings

### DIFF
--- a/tests/test_add_on_client.py
+++ b/tests/test_add_on_client.py
@@ -38,7 +38,7 @@ def test_valid_create_add_on_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/add_ons', content=mock_response())
-    response = client.add_ons().create(add_on_object())
+    response = client.add_ons.create(add_on_object())
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'add_on_code'
@@ -50,7 +50,7 @@ def test_invalid_create_add_on_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/add_ons', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.add_ons().create(add_on_object())
+        client.add_ons.create(add_on_object())
 
 
 def test_valid_update_add_on_request(httpx_mock: HTTPXMock):
@@ -58,7 +58,7 @@ def test_valid_update_add_on_request(httpx_mock: HTTPXMock):
     code = 'add_on_code'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/add_ons/' + code, content=mock_response())
-    response = client.add_ons().update(add_on_object(), code)
+    response = client.add_ons.update(add_on_object(), code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -71,7 +71,7 @@ def test_invalid_update_add_on_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/add_ons/' + code, status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.add_ons().update(add_on_object(), code)
+        client.add_ons.update(add_on_object(), code)
 
 
 def test_valid_find_add_on_request(httpx_mock: HTTPXMock):
@@ -79,7 +79,7 @@ def test_valid_find_add_on_request(httpx_mock: HTTPXMock):
     code = 'add_on_code'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/add_ons/' + code, content=mock_response())
-    response = client.add_ons().find(code)
+    response = client.add_ons.find(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -92,7 +92,7 @@ def test_invalid_find_add_on_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/add_ons/' + code, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.add_ons().find(code)
+        client.add_ons.find(code)
 
 
 def test_valid_destroy_add_on_request(httpx_mock: HTTPXMock):
@@ -100,7 +100,7 @@ def test_valid_destroy_add_on_request(httpx_mock: HTTPXMock):
     code = 'add_on_code'
 
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/add_ons/' + code, content=mock_response())
-    response = client.add_ons().destroy(code)
+    response = client.add_ons.destroy(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -113,14 +113,14 @@ def test_invalid_destroy_add_on_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/add_ons/' + code, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.add_ons().destroy(code)
+        client.add_ons.destroy(code)
 
 
 def test_valid_find_all_add_on_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/add_ons', content=mock_collection_response())
-    response = client.add_ons().find_all()
+    response = client.add_ons.find_all()
 
     assert response['add_ons'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
     assert response['meta']['current_page'] == 1
@@ -130,7 +130,7 @@ def test_valid_find_all_add_on_request_with_options(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/add_ons?per_page=2&page=1', content=mock_collection_response())
-    response = client.add_ons().find_all({'per_page': 2, 'page': 1})
+    response = client.add_ons.find_all({'per_page': 2, 'page': 1})
 
     assert response['add_ons'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1222'
     assert response['meta']['current_page'] == 1
@@ -142,4 +142,4 @@ def test_invalid_find_all_add_on_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/add_ons', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.add_ons().find_all()
+        client.add_ons.find_all()

--- a/tests/test_applied_add_on_client.py
+++ b/tests/test_applied_add_on_client.py
@@ -27,7 +27,7 @@ def test_valid_create_applied_add_on_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/applied_add_ons', content=mock_response())
-    response = client.applied_add_ons().create(create_applied_add_on())
+    response = client.applied_add_ons.create(create_applied_add_on())
 
     assert response.external_customer_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
@@ -38,4 +38,4 @@ def test_invalid_create_applied_add_on_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/applied_add_ons', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.applied_add_ons().create(create_applied_add_on())
+        client.applied_add_ons.create(create_applied_add_on())

--- a/tests/test_applied_coupon_client.py
+++ b/tests/test_applied_coupon_client.py
@@ -35,7 +35,7 @@ def test_valid_create_applied_coupon_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/applied_coupons', content=mock_response())
-    response = client.applied_coupons().create(create_applied_coupon())
+    response = client.applied_coupons.create(create_applied_coupon())
 
     assert response.external_customer_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
@@ -46,14 +46,14 @@ def test_invalid_create_applied_coupon_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/applied_coupons', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.applied_coupons().create(create_applied_coupon())
+        client.applied_coupons.create(create_applied_coupon())
 
 
 def test_valid_find_all_applied_coupon_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/applied_coupons', content=mock_collection_response())
-    response = client.applied_coupons().find_all()
+    response = client.applied_coupons.find_all()
 
     assert response['applied_coupons'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response['meta']['current_page'] == 1
@@ -63,7 +63,7 @@ def test_valid_find_all_applied_coupon_request_with_options(httpx_mock: HTTPXMoc
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/applied_coupons?per_page=2&page=1', content=mock_collection_response())
-    response = client.applied_coupons().find_all({'per_page': 2, 'page': 1})
+    response = client.applied_coupons.find_all({'per_page': 2, 'page': 1})
 
     assert response['applied_coupons'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac2222'
     assert response['meta']['current_page'] == 1
@@ -75,7 +75,7 @@ def test_invalid_find_all_applied_coupon_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/applied_coupons', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.applied_coupons().find_all()
+        client.applied_coupons.find_all()
 
 
 def test_valid_destroy_applied_coupon_request(httpx_mock: HTTPXMock):
@@ -88,7 +88,7 @@ def test_valid_destroy_applied_coupon_request(httpx_mock: HTTPXMock):
         url='https://api.getlago.com/api/v1/customers/' + external_customer_id + '/applied_coupons/' + applied_coupon_id,
         content=mock_response(),
     )
-    response = client.applied_coupons().destroy(external_customer_id, applied_coupon_id)
+    response = client.applied_coupons.destroy(external_customer_id, applied_coupon_id)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
 
@@ -105,4 +105,4 @@ def test_invalid_destroy_applied_coupon_request(httpx_mock: HTTPXMock):
         content=b'',
     )
     with pytest.raises(LagoApiError):
-        client.applied_coupons().destroy(external_customer_id, applied_coupon_id)
+        client.applied_coupons.destroy(external_customer_id, applied_coupon_id)

--- a/tests/test_billable_metric_client.py
+++ b/tests/test_billable_metric_client.py
@@ -43,7 +43,7 @@ def test_valid_create_billable_metric_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/billable_metrics', content=mock_response())
-    response = client.billable_metrics().create(billable_metric_object())
+    response = client.billable_metrics.create(billable_metric_object())
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'bm_code'
@@ -56,7 +56,7 @@ def test_invalid_create_billable_metric_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/billable_metrics', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.billable_metrics().create(billable_metric_object())
+        client.billable_metrics.create(billable_metric_object())
 
 
 def test_valid_update_billable_metric_request(httpx_mock: HTTPXMock):
@@ -64,7 +64,7 @@ def test_valid_update_billable_metric_request(httpx_mock: HTTPXMock):
     code = 'bm_code'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/billable_metrics/' + code, content=mock_response())
-    response = client.billable_metrics().update(billable_metric_object(), code)
+    response = client.billable_metrics.update(billable_metric_object(), code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -77,7 +77,7 @@ def test_invalid_update_billable_metric_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/billable_metrics/' + code, status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.billable_metrics().update(billable_metric_object(), code)
+        client.billable_metrics.update(billable_metric_object(), code)
 
 
 def test_valid_find_billable_metric_request(httpx_mock: HTTPXMock):
@@ -85,7 +85,7 @@ def test_valid_find_billable_metric_request(httpx_mock: HTTPXMock):
     code = 'bm_code'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/billable_metrics/' + code, content=mock_response())
-    response = client.billable_metrics().find(code)
+    response = client.billable_metrics.find(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -98,7 +98,7 @@ def test_invalid_find_billable_metric_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/billable_metrics/' + code, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.billable_metrics().find(code)
+        client.billable_metrics.find(code)
 
 
 def test_valid_destroy_billable_metric_request(httpx_mock: HTTPXMock):
@@ -106,7 +106,7 @@ def test_valid_destroy_billable_metric_request(httpx_mock: HTTPXMock):
     code = 'bm_code'
 
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/billable_metrics/' + code, content=mock_response())
-    response = client.billable_metrics().destroy(code)
+    response = client.billable_metrics.destroy(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -119,14 +119,14 @@ def test_invalid_destroy_billable_metric_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/billable_metrics/' + code, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.billable_metrics().destroy(code)
+        client.billable_metrics.destroy(code)
 
 
 def test_valid_find_all_billable_metric_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/billable_metrics', content=mock_collection_response())
-    response = client.billable_metrics().find_all()
+    response = client.billable_metrics.find_all()
 
     assert response['billable_metrics'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1000'
     assert response['meta']['current_page'] == 1
@@ -136,7 +136,7 @@ def test_valid_find_all_billable_metric_request_with_options(httpx_mock: HTTPXMo
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/billable_metrics?per_page=2&page=1', content=mock_collection_response())
-    response = client.billable_metrics().find_all({'per_page': 2, 'page': 1})
+    response = client.billable_metrics.find_all({'per_page': 2, 'page': 1})
 
     assert response['billable_metrics'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314a11111'
     assert response['meta']['current_page'] == 1
@@ -148,4 +148,4 @@ def test_invalid_find_all_billable_metric_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/billable_metrics', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.billable_metrics().find_all()
+        client.billable_metrics.find_all()

--- a/tests/test_coupon_client.py
+++ b/tests/test_coupon_client.py
@@ -43,7 +43,7 @@ def test_valid_create_coupon_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/coupons', content=mock_response())
-    response = client.coupons().create(coupon_object())
+    response = client.coupons.create(coupon_object())
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'coupon_code'
@@ -55,7 +55,7 @@ def test_invalid_create_coupon_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/coupons', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.coupons().create(coupon_object())
+        client.coupons.create(coupon_object())
 
 
 def test_valid_update_coupon_request(httpx_mock: HTTPXMock):
@@ -63,7 +63,7 @@ def test_valid_update_coupon_request(httpx_mock: HTTPXMock):
     code = 'coupon_code'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/coupons/' + code, content=mock_response())
-    response = client.coupons().update(coupon_object(), code)
+    response = client.coupons.update(coupon_object(), code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -76,7 +76,7 @@ def test_invalid_update_coupon_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/coupons/' + code, status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.coupons().update(coupon_object(), code)
+        client.coupons.update(coupon_object(), code)
 
 
 def test_valid_find_coupon_request(httpx_mock: HTTPXMock):
@@ -84,7 +84,7 @@ def test_valid_find_coupon_request(httpx_mock: HTTPXMock):
     code = 'coupon_code'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/coupons/' + code, content=mock_response())
-    response = client.coupons().find(code)
+    response = client.coupons.find(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -97,7 +97,7 @@ def test_invalid_find_coupon_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/coupons/' + code, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.coupons().find(code)
+        client.coupons.find(code)
 
 
 def test_valid_destroy_coupon_request(httpx_mock: HTTPXMock):
@@ -105,7 +105,7 @@ def test_valid_destroy_coupon_request(httpx_mock: HTTPXMock):
     code = 'coupon_code'
 
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/coupons/' + code, content=mock_response())
-    response = client.coupons().destroy(code)
+    response = client.coupons.destroy(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -118,14 +118,14 @@ def test_invalid_destroy_coupon_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/coupons/' + code, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.coupons().destroy(code)
+        client.coupons.destroy(code)
 
 
 def test_valid_find_all_coupon_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/coupons', content=mock_collection_response())
-    response = client.coupons().find_all()
+    response = client.coupons.find_all()
 
     assert response['coupons'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
     assert response['meta']['current_page'] == 1
@@ -135,7 +135,7 @@ def test_valid_find_all_coupon_request_with_options(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/coupons?per_page=2&page=1', content=mock_collection_response())
-    response = client.coupons().find_all({'per_page': 2, 'page': 1})
+    response = client.coupons.find_all({'per_page': 2, 'page': 1})
 
     assert response['coupons'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1222'
     assert response['meta']['current_page'] == 1
@@ -147,4 +147,4 @@ def test_invalid_find_all_coupon_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/coupons', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.coupons().find_all()
+        client.coupons.find_all()

--- a/tests/test_credit_note_client.py
+++ b/tests/test_credit_note_client.py
@@ -54,7 +54,7 @@ def test_valid_find_credit_note_request(httpx_mock: HTTPXMock):
     identifier = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/credit_notes/' + identifier, content=mock_response())
-    response = client.credit_notes().find(identifier)
+    response = client.credit_notes.find(identifier)
 
     assert response.lago_id == identifier
 
@@ -66,14 +66,14 @@ def test_invalid_find_invoice_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/credit_notes/' + identifier, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.credit_notes().find(identifier)
+        client.credit_notes.find(identifier)
 
 
 def test_valid_find_all_credit_notes_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/credit_notes?per_page=2&page=1', content=mock_collection_response())
-    response = client.credit_notes().find_all({'per_page': 2, 'page': 1})
+    response = client.credit_notes.find_all({'per_page': 2, 'page': 1})
 
     assert response['credit_notes'][0].lago_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
     assert response['meta']['current_page'] == 1
@@ -87,7 +87,7 @@ def test_valid_download_credit_note_request(httpx_mock: HTTPXMock):
         url='https://api.getlago.com/api/v1/credit_notes/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba/download',
         content=mock_response(),
     )
-    response = client.credit_notes().download('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+    response = client.credit_notes.download('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
     assert response.lago_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
@@ -96,7 +96,7 @@ def test_valid_create_credit_note_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/credit_notes', content=mock_response())
-    response = client.credit_notes().create(credit_note_object())
+    response = client.credit_notes.create(credit_note_object())
 
     assert response.lago_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.refund_status == 'pending'
@@ -108,7 +108,7 @@ def test_invalid_create_credit_note_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/credit_notes', status_code=422, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.credit_notes().create(credit_note_object())
+        client.credit_notes.create(credit_note_object())
 
 
 def test_valid_update_credit_note_request(httpx_mock: HTTPXMock):
@@ -116,7 +116,7 @@ def test_valid_update_credit_note_request(httpx_mock: HTTPXMock):
     credit_note_id = 'credit-note-id'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/credit_notes/' + credit_note_id, content=mock_response())
-    response = client.credit_notes().update(credit_note_update_object(), credit_note_id)
+    response = client.credit_notes.update(credit_note_update_object(), credit_note_id)
 
     assert response.lago_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.refund_status == 'pending'
@@ -127,7 +127,7 @@ def test_valid_void_credit_note_request(httpx_mock: HTTPXMock):
     credit_note_id = 'credit-note-id'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/credit_notes/' + credit_note_id + '/void', content=mock_response())
-    response = client.credit_notes().void(credit_note_id)
+    response = client.credit_notes.void(credit_note_id)
 
     assert response.lago_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.refund_status == 'pending'

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -44,7 +44,7 @@ def test_valid_create_customers_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/customers', content=mock_response())
-    response = client.customers().create(create_customer())
+    response = client.customers.create(create_customer())
 
     assert response.external_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
     assert response.name == 'Gavin Belson'
@@ -66,7 +66,7 @@ def test_invalid_create_customers_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/customers', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.customers().create(create_customer())
+        client.customers.create(create_customer())
 
 
 def test_valid_current_usage(httpx_mock: HTTPXMock):
@@ -77,7 +77,7 @@ def test_valid_current_usage(httpx_mock: HTTPXMock):
         url='https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123',
         content=mock_response('customer_usage'),
     )
-    response = client.customers().current_usage('external_customer_id', '123')
+    response = client.customers.current_usage('external_customer_id', '123')
 
     assert response.from_datetime == '2022-07-01T00:00:00Z'
     assert len(response.charges_usage) == 1
@@ -95,7 +95,7 @@ def test_invalid_current_usage(httpx_mock: HTTPXMock):
     )
 
     with pytest.raises(LagoApiError):
-        client.customers().current_usage('invalid_customer', '123')
+        client.customers.current_usage('invalid_customer', '123')
 
 
 def test_valid_portal_url(httpx_mock: HTTPXMock):
@@ -106,7 +106,7 @@ def test_valid_portal_url(httpx_mock: HTTPXMock):
         url='https://api.getlago.com/api/v1/customers/external_customer_id/portal_url',
         content=mock_response('customer_portal_url'),
     )
-    response = client.customers().portal_url('external_customer_id')
+    response = client.customers.portal_url('external_customer_id')
 
     assert response == "https://app.lago.dev/customer-portal/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3WkdGbE1qWmxZUzFqWlRnekxUUTJZell0T1dRNFl5MHdabVF4TURabFlqY3dNVElHT2daRlZBPT0iLCJleHAiOiIyMDIzLTAzLTIzVDIzOjAzOjAwLjM2NloiLCJwdXIiOm51bGx9fQ==--7128c6e541adc7b4c14249b1b18509f92e652d17"
 
@@ -117,7 +117,7 @@ def test_invalid_portal_url(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/customers/invalid_customer/portal_url', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.customers().portal_url('invalid_customer')
+        client.customers.portal_url('invalid_customer')
 
 
 def test_valid_destroy_customer_request(httpx_mock: HTTPXMock):
@@ -125,7 +125,7 @@ def test_valid_destroy_customer_request(httpx_mock: HTTPXMock):
     external_id = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/customers/' + external_id, content=mock_response())
-    response = client.customers().destroy(external_id)
+    response = client.customers.destroy(external_id)
 
     assert response.lago_id == '99a6094e-199b-4101-896a-54e927ce7bd7'
     assert response.external_id == external_id
@@ -138,4 +138,4 @@ def test_invalid_destroy_customer_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/customers/' + external_id, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.customers().destroy(external_id)
+        client.customers.destroy(external_id)

--- a/tests/test_event_client.py
+++ b/tests/test_event_client.py
@@ -35,7 +35,7 @@ def test_valid_create_events_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/events', content=b'')
-    client.events().create(create_event())  # Any response means success, any exception - failure
+    client.events.create(create_event())  # Any response means success, any exception - failure
 
 
 def test_invalid_create_events_request(httpx_mock: HTTPXMock):
@@ -44,14 +44,14 @@ def test_invalid_create_events_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/events', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.events().create(create_event())
+        client.events.create(create_event())
 
 
 def test_valid_create_batch_events_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/events/batch', content=b'')
-    client.events().batch_create(create_batch_event())  # Any response means success, any exception - failure
+    client.events.batch_create(create_batch_event())  # Any response means success, any exception - failure
 
 
 def test_invalid_create_batch_events_request(httpx_mock: HTTPXMock):
@@ -60,7 +60,7 @@ def test_invalid_create_batch_events_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/events/batch', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.events().batch_create(create_batch_event())
+        client.events.batch_create(create_batch_event())
 
 
 def test_valid_find_event_request(httpx_mock: HTTPXMock):
@@ -68,7 +68,7 @@ def test_valid_find_event_request(httpx_mock: HTTPXMock):
     event_id = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/events/' + event_id, content=mock_response())
-    response = client.events().find(event_id)
+    response = client.events.find(event_id)
 
     assert response.lago_id == event_id
 
@@ -80,14 +80,14 @@ def test_invalid_find_events_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/events/' + event_id, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.events().find(event_id)
+        client.events.find(event_id)
 
 
 def test_valid_estimate_fees_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/events/estimate_fees', content=mock_fees_response())
-    response = client.events().estimate_fees(create_event())
+    response = client.events.estimate_fees(create_event())
 
     assert response['fees'][0].item.type == 'instant_charge'
 
@@ -98,4 +98,4 @@ def test_invalid_estimate_fees_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/events/estimate_fees', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.events().estimate_fees(create_event())
+        client.events.estimate_fees(create_event())

--- a/tests/test_fee_client.py
+++ b/tests/test_fee_client.py
@@ -18,6 +18,6 @@ def test_valid_find_fee_request(httpx_mock: HTTPXMock):
     identifier = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/fees/' + identifier, content=mock_response())
-    response = client.fees().find(identifier)
+    response = client.fees.find(identifier)
 
     assert response.lago_id == identifier

--- a/tests/test_functools_ext.py
+++ b/tests/test_functools_ext.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 from lago_python_client.functools_ext import callable_cached_property
 
 
@@ -14,6 +16,7 @@ class Client:
         return InternalCollectionClient()
 
 
+@pytest.mark.filterwarnings("ignore:We are going to deprecate callable properties")  # we need test both cases to ensure we keep compatibility
 def test_callable_cached_property():
     # Given `InternalCollectionClient` class
     # And `Client` class with `callable_cached_property` decorator on `collection` method

--- a/tests/test_group_client.py
+++ b/tests/test_group_client.py
@@ -21,7 +21,7 @@ def test_valid_find_all_groups_request(httpx_mock: HTTPXMock):
         url='https://api.getlago.com/api/v1/billable_metrics/bm_code/groups?per_page=2&page=1',
         content=mock_collection_response(),
     )
-    response = client.groups().find_all('bm_code', {'per_page': 2, 'page': 1})
+    response = client.groups.find_all('bm_code', {'per_page': 2, 'page': 1})
 
     assert response['groups'][0].lago_id == '12345678-1de8-4428-9bcd-779314ac1111'
     assert response['meta']['current_page'] == 1

--- a/tests/test_invoice_client.py
+++ b/tests/test_invoice_client.py
@@ -35,7 +35,7 @@ def test_valid_update_invoice_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/invoices/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba', content=mock_response())
-    response = client.invoices().update(update_invoice_object(), '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+    response = client.invoices.update(update_invoice_object(), '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
     assert response.lago_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
     assert response.status == 'finalized'
@@ -50,7 +50,7 @@ def test_invalid_update_invoice_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/invoices/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.invoices().update(update_invoice_object(), '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+        client.invoices.update(update_invoice_object(), '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
 
 def test_valid_find_invoice_request(httpx_mock: HTTPXMock):
@@ -58,7 +58,7 @@ def test_valid_find_invoice_request(httpx_mock: HTTPXMock):
     identifier = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/invoices/' + identifier, content=mock_response())
-    response = client.invoices().find(identifier)
+    response = client.invoices.find(identifier)
 
     assert response.lago_id == identifier
 
@@ -70,14 +70,14 @@ def test_invalid_find_invoice_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/invoices/' + identifier, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.invoices().find(identifier)
+        client.invoices.find(identifier)
 
 
 def test_valid_find_all_invoice_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/invoices', content=mock_collection_response())
-    response = client.invoices().find_all()
+    response = client.invoices.find_all()
 
     assert response['invoices'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
     assert response['meta']['current_page'] == 1
@@ -87,7 +87,7 @@ def test_valid_find_all_invoice_request_with_options(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/invoices?per_page=2&page=1', content=mock_collection_response())
-    response = client.invoices().find_all({'per_page': 2, 'page': 1})
+    response = client.invoices.find_all({'per_page': 2, 'page': 1})
 
     assert response['invoices'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1222'
     assert response['meta']['current_page'] == 1
@@ -99,14 +99,14 @@ def test_invalid_find_all_invoice_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/invoices', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.invoices().find_all()
+        client.invoices.find_all()
 
 
 def test_valid_download_invoice_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/invoices/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba/download', content=mock_response())
-    response = client.invoices().download('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+    response = client.invoices.download('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
     assert response.lago_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
@@ -115,7 +115,7 @@ def test_valid_refresh_invoice_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/invoices/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba/refresh', content=mock_response())
-    response = client.invoices().refresh('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+    response = client.invoices.refresh('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
     assert response.lago_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
@@ -124,7 +124,7 @@ def test_valid_finalize_invoice_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/invoices/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba/finalize', content=mock_response())
-    response = client.invoices().finalize('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+    response = client.invoices.finalize('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
     assert response.lago_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
 
@@ -137,6 +137,6 @@ def test_valid_retry_payment_invoice_request(httpx_mock: HTTPXMock):
         url='https://api.getlago.com/api/v1/invoices/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba/retry_payment',
         content=mock_response(),
     )
-    response = client.invoices().retry_payment('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
+    response = client.invoices.retry_payment('5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba')
 
     assert response.lago_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'

--- a/tests/test_organization_client.py
+++ b/tests/test_organization_client.py
@@ -32,7 +32,7 @@ def test_valid_update_organization_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/organizations', content=mock_response())
-    response = client.organizations().update(organization_object())
+    response = client.organizations.update(organization_object())
 
     assert response.name == 'Hooli'
 
@@ -43,4 +43,4 @@ def test_invalid_update_organization_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/organizations', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.organizations().update(organization_object())
+        client.organizations.update(organization_object())

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -101,7 +101,7 @@ def test_valid_create_plan_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/plans', content=mock_response())
-    response = client.plans().create(plan_object())
+    response = client.plans.create(plan_object())
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'plan_code'
@@ -111,7 +111,7 @@ def test_valid_create_graduated_plan_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/plans', content=mock_graduated_response())
-    response = client.plans().create(graduated_plan_object())
+    response = client.plans.create(graduated_plan_object())
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'plan_code'
@@ -123,7 +123,7 @@ def test_invalid_create_plan_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/plans', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.plans().create(plan_object())
+        client.plans.create(plan_object())
 
 
 def test_valid_update_plan_request(httpx_mock: HTTPXMock):
@@ -131,7 +131,7 @@ def test_valid_update_plan_request(httpx_mock: HTTPXMock):
     code = 'plan_code'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/plans/' + code, content=mock_response())
-    response = client.plans().update(plan_object(), code)
+    response = client.plans.update(plan_object(), code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -144,7 +144,7 @@ def test_invalid_update_plan_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/plans/' + code, status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.plans().update(plan_object(), code)
+        client.plans.update(plan_object(), code)
 
 
 def test_valid_find_plan_request(httpx_mock: HTTPXMock):
@@ -152,7 +152,7 @@ def test_valid_find_plan_request(httpx_mock: HTTPXMock):
     code = 'plan_code'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/plans/' + code, content=mock_response())
-    response = client.plans().find(code)
+    response = client.plans.find(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -166,7 +166,7 @@ def test_invalid_find_plan_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/plans/' + code, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.plans().find(code)
+        client.plans.find(code)
 
 
 def test_valid_destroy_plan_request(httpx_mock: HTTPXMock):
@@ -174,7 +174,7 @@ def test_valid_destroy_plan_request(httpx_mock: HTTPXMock):
     code = 'plan_code'
 
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/plans/' + code, content=mock_response())
-    response = client.plans().destroy(code)
+    response = client.plans.destroy(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
@@ -187,14 +187,14 @@ def test_invalid_destroy_plan_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/plans/' + code, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.plans().destroy(code)
+        client.plans.destroy(code)
 
 
 def test_valid_find_all_plan_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/plans', content=mock_collection_response())
-    response = client.plans().find_all()
+    response = client.plans.find_all()
 
     assert response['plans'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
     assert response['meta']['current_page'] == 1
@@ -204,7 +204,7 @@ def test_valid_find_all_plan_request_with_options(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/plans?per_page=2&page=1', content=mock_collection_response())
-    response = client.plans().find_all({'per_page': 2, 'page': 1})
+    response = client.plans.find_all({'per_page': 2, 'page': 1})
 
     assert response['plans'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1222'
     assert response['meta']['current_page'] == 1
@@ -216,4 +216,4 @@ def test_invalid_find_all_plan_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/plans', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.plans().find_all()
+        client.plans.find_all()

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -33,7 +33,7 @@ def test_valid_create_subscriptions_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/subscriptions', content=mock_response())
-    response = client.subscriptions().create(create_subscription())
+    response = client.subscriptions.create(create_subscription())
 
     assert response.external_customer_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
     assert response.status == 'active'
@@ -48,7 +48,7 @@ def test_invalid_create_subscriptions_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/subscriptions', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.subscriptions().create(create_subscription())
+        client.subscriptions.create(create_subscription())
 
 
 def test_valid_update_subscription_request(httpx_mock: HTTPXMock):
@@ -56,7 +56,7 @@ def test_valid_update_subscription_request(httpx_mock: HTTPXMock):
     identifier = 'sub_id'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/subscriptions/' + identifier, content=mock_response())
-    response = client.subscriptions().update(Subscription(name='name'), identifier)
+    response = client.subscriptions.update(Subscription(name='name'), identifier)
 
     assert response.external_customer_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
     assert response.status == 'active'
@@ -72,7 +72,7 @@ def test_invalid_update_subscription_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/subscriptions/' + identifier, status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.subscriptions().update(Subscription(name='name'), identifier)
+        client.subscriptions.update(Subscription(name='name'), identifier)
 
 
 def test_valid_destroy_subscription_request(httpx_mock: HTTPXMock):
@@ -80,7 +80,7 @@ def test_valid_destroy_subscription_request(httpx_mock: HTTPXMock):
     identifier = 'sub_id'
 
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/subscriptions/' + identifier, content=mock_response())
-    response = client.subscriptions().destroy(identifier)
+    response = client.subscriptions.destroy(identifier)
 
     assert response.external_customer_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
     assert response.status == 'active'
@@ -94,14 +94,14 @@ def test_invalid_destroy_subscription_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/subscriptions/' + identifier, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.subscriptions().destroy(identifier)
+        client.subscriptions.destroy(identifier)
 
 
 def test_valid_find_all_subscription_request_with_options(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/subscriptions?external_customer_id=123', content=mock_collection_response())
-    response = client.subscriptions().find_all({'external_customer_id': '123'})
+    response = client.subscriptions.find_all({'external_customer_id': '123'})
 
     assert response['subscriptions'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response['meta']['current_page'] == 1
@@ -113,4 +113,4 @@ def test_invalid_find_all_subscription_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/subscriptions', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.subscriptions().find_all()
+        client.subscriptions.find_all()

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -38,7 +38,7 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/wallets', content=mock_response())
-    response = client.wallets().create(wallet_object())
+    response = client.wallets.create(wallet_object())
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
 
@@ -49,7 +49,7 @@ def test_invalid_create_wallet_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/wallets', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.wallets().create(wallet_object())
+        client.wallets.create(wallet_object())
 
 
 def test_valid_update_wallet_request(httpx_mock: HTTPXMock):
@@ -57,7 +57,7 @@ def test_valid_update_wallet_request(httpx_mock: HTTPXMock):
     arg = 'b7ab2926-1de8-4428-9bcd-779314ac129b'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/wallets/' + arg, content=mock_response())
-    response = client.wallets().update(wallet_object(), arg)
+    response = client.wallets.update(wallet_object(), arg)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
 
@@ -69,7 +69,7 @@ def test_invalid_update_wallet_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/wallets/' + arg, status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.wallets().update(wallet_object(), arg)
+        client.wallets.update(wallet_object(), arg)
 
 
 def test_valid_find_wallet_request(httpx_mock: HTTPXMock):
@@ -77,7 +77,7 @@ def test_valid_find_wallet_request(httpx_mock: HTTPXMock):
     arg = 'b7ab2926-1de8-4428-9bcd-779314ac129b'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/wallets/' + arg, content=mock_response())
-    response = client.wallets().find(arg)
+    response = client.wallets.find(arg)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
 
@@ -89,7 +89,7 @@ def test_invalid_find_wallet_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/wallets/' + arg, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.wallets().find(arg)
+        client.wallets.find(arg)
 
 
 def test_valid_destroy_wallet_request(httpx_mock: HTTPXMock):
@@ -97,7 +97,7 @@ def test_valid_destroy_wallet_request(httpx_mock: HTTPXMock):
     arg = 'b7ab2926-1de8-4428-9bcd-779314ac129b'
 
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/wallets/' + arg, content=mock_response())
-    response = client.wallets().destroy(arg)
+    response = client.wallets.destroy(arg)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
 
@@ -109,14 +109,14 @@ def test_invalid_destroy_wallet_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/wallets/' + arg, status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.wallets().destroy(arg)
+        client.wallets.destroy(arg)
 
 
 def test_valid_find_all_wallet_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/wallets', content=mock_collection_response())
-    response = client.wallets().find_all()
+    response = client.wallets.find_all()
 
     assert response['wallets'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response['meta']['current_page'] == 1
@@ -130,7 +130,7 @@ def test_valid_find_all_wallet_request_with_options(httpx_mock: HTTPXMock):
         url='https://api.getlago.com/api/v1/wallets?external_customer_id=123&per_page=2&page=1',
         content=mock_collection_response(),
     )
-    response = client.wallets().find_all({'external_customer_id': 123, 'per_page': 2, 'page': 1})
+    response = client.wallets.find_all({'external_customer_id': 123, 'per_page': 2, 'page': 1})
 
     assert response['wallets'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
     assert response['meta']['current_page'] == 1
@@ -142,4 +142,4 @@ def test_invalid_find_all_wallet_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/wallets', status_code=404, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.wallets().find_all()
+        client.wallets.find_all()

--- a/tests/test_wallet_transaction_client.py
+++ b/tests/test_wallet_transaction_client.py
@@ -36,7 +36,7 @@ def test_valid_create_wallet_transaction_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/wallet_transactions', content=mock_response())
-    response = client.wallet_transactions().create(wallet_transaction_object())
+    response = client.wallet_transactions.create(wallet_transaction_object())
 
     assert response['wallet_transactions'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
     assert response['wallet_transactions'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1222'
@@ -48,14 +48,14 @@ def test_invalid_create_wallet_transaction_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/wallet_transactions', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.wallet_transactions().create(wallet_transaction_object())
+        client.wallet_transactions.create(wallet_transaction_object())
 
 
 def test_valid_find_all_groups_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/wallets/555/wallet_transactions', content=mock_collection_response())
-    response = client.wallet_transactions().find_all('555')
+    response = client.wallet_transactions.find_all('555')
 
     assert response['wallet_transactions'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
     assert response['meta']['current_page'] == 1

--- a/tests/test_webhook_client.py
+++ b/tests/test_webhook_client.py
@@ -19,7 +19,7 @@ def test_valid_public_key_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/webhooks/json_public_key', content=mock_response())
-    response = client.webhooks().public_key()
+    response = client.webhooks.public_key()
 
     assert response == b'key'
 
@@ -30,4 +30,4 @@ def test_invalid_public_key_request(httpx_mock: HTTPXMock):
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/webhooks/json_public_key', status_code=401, content=b'')
 
     with pytest.raises(LagoApiError):
-        client.webhooks().public_key()
+        client.webhooks.public_key()


### PR DESCRIPTION
Remove `client.<tag>` braces in tests to hide pytest warnings (except one test where it's required to test compatibility)...