### PR TITLE
Fix #145 - Add `number` field to `InvoiceResponse` model

### DIFF
--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -32,6 +32,7 @@ class Invoice(BaseModel):
 class InvoiceResponse(BaseResponseModel):
     lago_id: str
     sequential_id: int
+    number: str
     issuing_date: Optional[str]
     invoice_type: str
     status: str

--- a/tests/fixtures/invoice.json
+++ b/tests/fixtures/invoice.json
@@ -2,6 +2,7 @@
   "invoice": {
     "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "sequential_id": 15,
+    "number": "LAG-1234-001-002",
     "from_date": "2022-06-02",
     "to_date": "2022-06-02",
     "charges_from_date": "2022-06-02",

--- a/tests/fixtures/invoice_index.json
+++ b/tests/fixtures/invoice_index.json
@@ -3,6 +3,7 @@
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1111",
       "sequential_id": 15,
+      "number": "LAG-1234-001-002",
       "from_date": "2022-06-02",
       "to_date": "2022-06-02",
       "charges_from_date": "2022-06-02",
@@ -20,6 +21,7 @@
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1222",
       "sequential_id": 16,
+      "number": "LAG-1234-001-002",
       "from_date": "2022-06-02",
       "to_date": "2022-06-02",
       "charges_from_date": "2022-06-02",

--- a/tests/fixtures/invoice_index.json
+++ b/tests/fixtures/invoice_index.json
@@ -21,7 +21,7 @@
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1222",
       "sequential_id": 16,
-      "number": "LAG-1234-001-002",
+      "number": "LAG-1234-001-003",
       "from_date": "2022-06-02",
       "to_date": "2022-06-02",
       "charges_from_date": "2022-06-02",


### PR DESCRIPTION
Related issue:
- #145 

https://doc.getlago.com/docs/api/invoices/invoice-object