### PR TITLE
feat(min_charge): Ability to specify a minimum amount for a charge

### DIFF
--- a/lago_python_client/models/charge.py
+++ b/lago_python_client/models/charge.py
@@ -15,6 +15,7 @@ class Charge(BaseModel):
     billable_metric_id: Optional[str]
     charge_model: Optional[str]
     instant: Optional[bool]
+    min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
     group_properties: Optional[GroupProperties]
 
@@ -28,6 +29,8 @@ class ChargeResponse(BaseResponseModel):
     lago_billable_metric_id: Optional[str]
     billable_metric_code: Optional[str]
     charge_model: Optional[str]
+    instant: Optional[bool]
+    min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
     group_properties: Optional[GroupProperties]
 

--- a/lago_python_client/models/fee.py
+++ b/lago_python_client/models/fee.py
@@ -10,6 +10,7 @@ class FeeResponse(BaseResponseModel):
     lago_id: Optional[str]
     lago_group_id: Optional[str]
     lago_invoice_id: Optional[str]
+    lago_true_up_fee_id: Optional[str]
     external_subscription_id: Optional[str]
     amount_cents: Optional[int]
     amount_currency: Optional[str]

--- a/tests/fixtures/fee.json
+++ b/tests/fixtures/fee.json
@@ -2,6 +2,8 @@
   "fee": {
     "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "lago_group_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+    "lago_invoice_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+    "lago_true_up_fee_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "item": {
       "type": "charge",
       "code": "fee_code",

--- a/tests/fixtures/fees.json
+++ b/tests/fixtures/fees.json
@@ -3,6 +3,8 @@
     {
       "lago_id": "nil",
       "lago_group_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+      "lago_invoice_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+      "lago_true_up_fee_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
       "item": {
         "type": "instant_charge",
         "code": "fee_code",

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -22,6 +22,7 @@
         "amount_currency": "EUR",
         "charge_model": "standard",
         "instant": true,
+        "min_amount_cents": 0,
         "properties": {
           "amount": "0.22"
         }

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -14,6 +14,7 @@ def plan_object():
         charge_model='standard',
         amount_currency='EUR',
         instant=True,
+        min_amount_cents=0,
         group_properties = [
             {
                 'group_id': 'id',
@@ -157,6 +158,7 @@ def test_valid_find_plan_request(httpx_mock: HTTPXMock):
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
     assert response.charges.__root__[0].charge_model == 'standard'
+    assert response.charges.__root__[0].min_amount_cents == 0
 
 
 def test_invalid_find_plan_request(httpx_mock: HTTPXMock):


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to:
- add min_amount_cents to Charge
- add lago_true_up_fee_id to Fee