### PR TITLE
feat(coupon): Add new fields and refactoring for coupons applied befo…

### DIFF
--- a/lago_python_client/models/credit.py
+++ b/lago_python_client/models/credit.py
@@ -15,6 +15,7 @@ class CreditResponse(BaseResponseModel):
     lago_id: Optional[str]
     amount_cents: Optional[int]
     amount_currency: Optional[str]
+    before_vat: bool
     item: Optional[InvoiceItemResponse]
     invoice: Optional[InvoiceShortDetails]
 

--- a/lago_python_client/models/credit_note.py
+++ b/lago_python_client/models/credit_note.py
@@ -28,22 +28,26 @@ class CreditNoteResponse(BaseResponseModel):
     credit_status: Optional[str]
     refund_status: Optional[str]
     reason: Optional[str]
-    total_amount_cents: Optional[int]
-    total_amount_currency: Optional[str]
-    credit_amount_cents: Optional[int]
-    credit_amount_currency: Optional[str]
-    balance_amount_cents: Optional[int]
-    balance_amount_currency: Optional[str]
-    refund_amount_cents: Optional[int]
-    refund_amount_currency: Optional[str]
-    vat_amount_cents: Optional[str]
-    vat_amount_currency: Optional[str]
-    sub_total_vat_excluded_amount_cents: Optional[str]
-    sub_total_vat_excluded_amount_currency: Optional[str]
+    currency: str
+    total_amount_cents: int
+    credit_amount_cents: int
+    balance_amount_cents: int
+    refund_amount_cents: int
+    vat_amount_cents: str
+    sub_total_vat_excluded_amount_cents: int
+    coupons_adjustement_amount_cents: int
     file_url: Optional[str]
     created_at: Optional[str]
     updated_at: Optional[str]
     items: Optional[ItemsResponse]
+
+    # NOTE(legacy): Deprecated fields that will be removed in the future
+    total_amount_currency: Optional[str]
+    credit_amount_currency: Optional[str]
+    refund_amount_currency: Optional[str]
+    balance_amount_currency: Optional[str]
+    vat_amount_currency: Optional[str]
+    sub_total_vat_excluded_amount_currency: Optional[str]
 
 
 class Item(BaseModel):

--- a/tests/fixtures/credit_note.json
+++ b/tests/fixtures/credit_note.json
@@ -8,6 +8,7 @@
     "credit_status": "available",
     "refund_status": "pending",
     "reason": "other",
+    "currency": "EUR",
     "total_amount_cents": 240,
     "total_amount_currency": "EUR",
     "credit_amount_cents": 100,
@@ -20,6 +21,7 @@
     "vat_amount_currency": "EUR",
     "sub_total_vat_excluded_amount_cents": 200,
     "sub_total_vat_excluded_amount_currency": "EUR",
+    "coupons_adjustement_amount_cents": 0,
     "created_at": "2022-10-04 16:21:00",
     "updated_at": "2022-10-04 16:21:00",
     "items": [

--- a/tests/fixtures/credit_note_index.json
+++ b/tests/fixtures/credit_note_index.json
@@ -9,6 +9,7 @@
       "credit_status": "available",
       "refund_status": "pending",
       "reason": "other",
+      "currency": "EUR",
       "total_amount_cents": 100,
       "total_amount_currency": "EUR",
       "credit_amount_cents": 100,
@@ -21,6 +22,7 @@
       "vat_amount_currency": "EUR",
       "sub_total_vat_excluded_amount_cents": 200,
       "sub_total_vat_excluded_amount_currency": "EUR",
+      "coupons_adjustement_amount_cents": 0,
       "created_at": "2022-10-04 16:21:00",
       "updated_at": "2022-10-04 16:21:00"
     }

--- a/tests/fixtures/invoice.json
+++ b/tests/fixtures/invoice.json
@@ -89,6 +89,7 @@
       {
         "amount_cents": 20,
         "amount_currency": "EUR",
+        "before_vat": true,
         "item": {
           "type": "coupon",
           "code": "free_beer",


### PR DESCRIPTION
# Update `CreditNote` definition:

## New fields
- `currency`
- `coupons_adjustement_amount_cents`

## Deprecated fields
- `total_amount_currency`
- `credit_amount_currency`
- `balance_amount_currency`
- `refund_amount_currency`
- `vat_amount_currency`
- `sub_total_vat_excluded_amount_currency`

# Update `InvoiceCredit` definition

## New field
- `before_vat`