### PR TITLE
feat(tax_rates): Add tax rate resource

### DIFF
--- a/lago_python_client/client.py
+++ b/lago_python_client/client.py
@@ -12,6 +12,7 @@ from .invoices.clients import InvoiceClient
 from .organizations.clients import OrganizationClient
 from .plans.clients import PlanClient
 from .subscriptions.clients import SubscriptionClient
+from .tax_rates.clients import TaxRateClient
 from .wallets.clients import WalletClient, WalletTransactionClient
 from .webhooks.clients import WebhookClient
 
@@ -88,6 +89,10 @@ class Client:
     @callable_cached_property
     def subscriptions(self) -> SubscriptionClient:
         return SubscriptionClient(self.base_api_url, self.api_key)
+
+    @callable_cached_property
+    def tax_rates(self) -> TaxRateClient:
+        return TaxRateClient(self.base_api_url, self.api_key)
 
     @callable_cached_property
     def wallets(self) -> WalletClient:

--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -16,5 +16,6 @@ from .invoice import InvoicePaymentStatusChange, Invoice, InvoiceMetadata, Invoi
 from .invoice_item import InvoiceItemResponse
 from .subscription import Subscription
 from .customer_usage import Metric, ChargeObject, ChargeUsage, CustomerUsageResponse
+from .tax_rate import TaxRate
 from .wallet import Wallet
 from .wallet_transaction import WalletTransaction

--- a/lago_python_client/models/tax_rate.py
+++ b/lago_python_client/models/tax_rate.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from ..base_model import BaseResponseModel
+
+
+class TaxRate(BaseModel):
+    name: Optional[str]
+    code: Optional[str]
+    value: Optional[float]
+    description: Optional[str]
+
+
+class TaxRateResponse(BaseResponseModel):
+    lago_id: str
+    name: str
+    code: str
+    value: float
+    description: Optional[str]
+    customers_count: int
+    created_at: str

--- a/lago_python_client/models/tax_rate.py
+++ b/lago_python_client/models/tax_rate.py
@@ -10,6 +10,7 @@ class TaxRate(BaseModel):
     code: Optional[str]
     value: Optional[float]
     description: Optional[str]
+    applied_by_default: Optional[bool]
 
 
 class TaxRateResponse(BaseResponseModel):
@@ -19,4 +20,5 @@ class TaxRateResponse(BaseResponseModel):
     value: float
     description: Optional[str]
     customers_count: int
+    applied_by_default: bool
     created_at: str

--- a/lago_python_client/tax_rates/clients.py
+++ b/lago_python_client/tax_rates/clients.py
@@ -1,0 +1,18 @@
+from typing import ClassVar, Type
+
+from ..base_client import BaseClient
+from ..mixins import CreateCommandMixin, DestroyCommandMixin, FindAllCommandMixin, FindCommandMixin, UpdateCommandMixin
+from ..models.tax_rate import TaxRateResponse
+
+
+class TaxRateClient(
+    CreateCommandMixin[TaxRateResponse],
+    DestroyCommandMixin[TaxRateResponse],
+    FindAllCommandMixin[TaxRateResponse],
+    FindCommandMixin[TaxRateResponse],
+    UpdateCommandMixin[TaxRateResponse],
+    BaseClient,
+):
+    API_RESOURCE: ClassVar[str] = 'tax_rates'
+    RESPONSE_MODEL: ClassVar[Type[TaxRateResponse]] = TaxRateResponse
+    ROOT_NAME: ClassVar[str] = 'tax_rate'

--- a/tests/fixtures/tax_rate.json
+++ b/tests/fixtures/tax_rate.json
@@ -6,6 +6,7 @@
     "value": 15.0,
     "description": "tax_rate_desc",
     "customers_count": 0,
+    "applied_by_default": false,
     "created_at": "2022-04-29T08:59:51Z"
   }
 }

--- a/tests/fixtures/tax_rate.json
+++ b/tests/fixtures/tax_rate.json
@@ -1,0 +1,11 @@
+{
+  "tax_rate": {
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "name": "tax_rate_name",
+    "code": "tax_rate_code",
+    "value": 15.0,
+    "description": "tax_rate_desc",
+    "customers_count": 0,
+    "created_at": "2022-04-29T08:59:51Z"
+  }
+}

--- a/tests/fixtures/tax_rate_index.json
+++ b/tests/fixtures/tax_rate_index.json
@@ -7,6 +7,7 @@
       "value": 15.0,
       "customers_count": 0,
       "description": "tax_rate_desc_1",
+      "applied_by_default": false,
       "created_at": "2022-04-29T08:59:51Z"
     },
     {
@@ -16,6 +17,7 @@
       "value": 20.0,
       "customers_count": 5,
       "description": "tax_rate_desc_2",
+      "applied_by_default": false,
       "created_at": "2022-04-29T08:59:51Z"
     }
   ],

--- a/tests/fixtures/tax_rate_index.json
+++ b/tests/fixtures/tax_rate_index.json
@@ -1,0 +1,29 @@
+{
+  "tax_rates": [
+    {
+      "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1111",
+      "name": "tax_rate_name_1",
+      "code": "tax_rate_code_1",
+      "value": 15.0,
+      "customers_count": 0,
+      "description": "tax_rate_desc_1",
+      "created_at": "2022-04-29T08:59:51Z"
+    },
+    {
+      "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1222",
+      "name": "tax_rate_name_2",
+      "code": "tax_rate_code_2",
+      "value": 20.0,
+      "customers_count": 5,
+      "description": "tax_rate_desc_2",
+      "created_at": "2022-04-29T08:59:51Z"
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "next_page": 2,
+    "prev_page": null,
+    "total_pages": 8,
+    "total_count": 73
+  }
+}

--- a/tests/test_tax_rate_client.py
+++ b/tests/test_tax_rate_client.py
@@ -1,0 +1,144 @@
+import os
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
+from lago_python_client.models.tax_rate import TaxRate
+
+
+def tax_rate_object():
+    return TaxRate(
+        name='name',
+        code='tax_rate_first',
+        value=15.0,
+        description='desc'
+    )
+
+
+def mock_response():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(this_dir, 'fixtures/tax_rate.json')
+
+    with open(data_path, 'rb') as tax_rate_response:
+        return tax_rate_response.read()
+
+
+def mock_collection_response():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(this_dir, 'fixtures/tax_rate_index.json')
+
+    with open(data_path, 'rb') as tax_rate_response:
+        return tax_rate_response.read()
+
+
+def test_valid_create_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+    httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/tax_rates', content=mock_response())
+    response = client.tax_rates.create(tax_rate_object())
+
+    assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
+    assert response.code == 'tax_rate_code'
+
+
+def test_invalid_create_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='invalid')
+
+    httpx_mock.add_response(method='POST', url='https://api.getlago.com/api/v1/tax_rates', status_code=401, content=b'')
+
+    with pytest.raises(LagoApiError):
+        client.tax_rates.create(tax_rate_object())
+
+
+def test_valid_update_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+    code = 'tax_rate_code'
+
+    httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/tax_rates/' + code, content=mock_response())
+    response = client.tax_rates.update(tax_rate_object(), code)
+
+    assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
+    assert response.code == code
+
+
+def test_invalid_update_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='invalid')
+    code = 'invalid'
+
+    httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/tax_rates/' + code, status_code=401, content=b'')
+
+    with pytest.raises(LagoApiError):
+        client.tax_rates.update(tax_rate_object(), code)
+
+
+def test_valid_find_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+    code = 'tax_rate_code'
+
+    httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/tax_rates/' + code, content=mock_response())
+    response = client.tax_rates.find(code)
+
+    assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
+    assert response.code == code
+
+
+def test_invalid_find_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='invalid')
+    code = 'invalid'
+
+    httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/tax_rates/' + code, status_code=404, content=b'')
+
+    with pytest.raises(LagoApiError):
+        client.tax_rates.find(code)
+
+
+def test_valid_destroy_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+    code = 'tax_rate_code'
+
+    httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/tax_rates/' + code, content=mock_response())
+    response = client.tax_rates.destroy(code)
+
+    assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
+    assert response.code == code
+
+
+def test_invalid_destroy_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='invalid')
+    code = 'invalid'
+
+    httpx_mock.add_response(method='DELETE', url='https://api.getlago.com/api/v1/tax_rates/' + code, status_code=404, content=b'')
+
+    with pytest.raises(LagoApiError):
+        client.tax_rates.destroy(code)
+
+
+def test_valid_find_all_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+    httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/tax_rates', content=mock_collection_response())
+    response = client.tax_rates.find_all()
+
+    assert response['tax_rates'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
+    assert response['meta']['current_page'] == 1
+
+
+def test_valid_find_all_tax_rate_request_with_options(httpx_mock: HTTPXMock):
+    client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+
+    httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/tax_rates?per_page=2&page=1', content=mock_collection_response())
+    response = client.tax_rates.find_all({'per_page': 2, 'page': 1})
+
+    assert response['tax_rates'][1].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1222'
+    assert response['meta']['current_page'] == 1
+
+
+def test_invalid_find_all_tax_rate_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='invalid')
+
+    httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/tax_rates', status_code=404, content=b'')
+
+    with pytest.raises(LagoApiError):
+        client.tax_rates.find_all()

--- a/tests/test_tax_rate_client.py
+++ b/tests/test_tax_rate_client.py
@@ -13,7 +13,8 @@ def tax_rate_object():
         name='name',
         code='tax_rate_first',
         value=15.0,
-        description='desc'
+        description='desc',
+        applied_by_default=False
     )
 
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to be able to add the TaxRate resource.