### PR TITLE
fix(charge): Group propeties should be a list

### DIFF
--- a/lago_python_client/models/charge.py
+++ b/lago_python_client/models/charge.py
@@ -10,6 +10,10 @@ class GroupProperties(BaseModel):
     values: Optional[Dict[str, Any]]
 
 
+class GroupPropertiesList(BaseModel):
+    __root__: List[GroupProperties]
+
+
 class Charge(BaseModel):
     id: Optional[str]
     billable_metric_id: Optional[str]
@@ -18,7 +22,7 @@ class Charge(BaseModel):
     invoiceable: Optional[bool]
     min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
-    group_properties: Optional[GroupProperties]
+    group_properties: Optional[GroupPropertiesList]
 
 
 class Charges(BaseModel):
@@ -34,7 +38,7 @@ class ChargeResponse(BaseResponseModel):
     invoiceable: Optional[bool]
     min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
-    group_properties: Optional[GroupProperties]
+    group_properties: Optional[GroupPropertiesList]
 
 
 class ChargesResponse(BaseResponseModel):

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -200,6 +200,9 @@ def test_valid_find_all_plan_request(httpx_mock: HTTPXMock):
     response = client.plans.find_all()
 
     assert response['plans'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
+    assert response['plans'][0].charges.__root__[0].lago_id == '51c1e851-5be6-4343-a0ee-39a81d8b4ee1'
+    assert response['plans'][0].charges.__root__[0].group_properties.__root__[0].group_id == 'gfc1e851-5be6-4343-a0ee-39a81d8b4ee1'
+    assert response['plans'][0].charges.__root__[0].group_properties.__root__[0].values['amount'] == '0.22'
     assert response['meta']['current_page'] == 1
 
 


### PR DESCRIPTION
# Description

This PR is a fix for the `charge#group_properties` definition.

In Lago API and in openapi definition, this `group_properties` is defined as an array of object, while the current implementation in the client expects an object
