### PR TITLE
feat(subscription) allow to pass status to index and delete

### DIFF
--- a/lago_python_client/mixins.py
+++ b/lago_python_client/mixins.py
@@ -64,13 +64,14 @@ class CreateCommandMixin(Generic[_M]):
 class DestroyCommandMixin(Generic[_M]):
     """Client mixin with `destroy` command."""
 
-    def destroy(self: _ClientMixin[_M], resource_id: str) -> BaseModel:
+    def destroy(self: _ClientMixin[_M], resource_id: str, options: Mapping[str, Union[int, str]] = {}) -> BaseModel:
         """Execute `destroy` command."""
         # Send request and save response
         api_response: Response = send_delete_request(
             url=make_url(
                 origin=self.base_url,
                 path_parts=(self.API_RESOURCE, resource_id),
+                query_pairs=options,
             ),
             headers=make_headers(api_key=self.api_key),
         )

--- a/tests/fixtures/pending_subscription.json
+++ b/tests/fixtures/pending_subscription.json
@@ -1,0 +1,18 @@
+{
+  "subscription": {
+    "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
+    "lago_customer_id": "99a6094e-199b-4101-896a-54e927ce7bd7",
+    "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "canceled_at": "2022-04-29T08:59:51Z",
+    "created_at": "2022-04-29T08:59:51Z",
+    "plan_code": "eartha lynch",
+    "started_at": "2022-04-29T08:59:51Z",
+    "status": "pending",
+    "billing_time": "anniversary",
+    "terminated_at": null,
+    "subscription_date": "2022-04-29",
+    "previous_plan_code": null,
+    "next_plan_code": null,
+    "downgrade_plan_date": null
+  }
+}


### PR DESCRIPTION
This PR adds 2 improvements

- You can now delete a pending subscription by passing a status=pending as query param
- You can now filter GET /subscriptions by passing an array of status as query param