### PR TITLE
fix: fetch coupons with percentage discount

### DIFF
--- a/lago_python_client/models/coupon.py
+++ b/lago_python_client/models/coupon.py
@@ -31,8 +31,8 @@ class CouponResponse(BaseResponseModel):
     name: str
     code: str
     description: Optional[str]
-    amount_cents: int
-    amount_currency: str
+    amount_cents: Optional[int]
+    amount_currency: Optional[str]
     created_at: str
     expiration: str
     expiration_at: Optional[str]


### PR DESCRIPTION
Fetching coupons with percentage discount raise the error

```
pydantic.error_wrappers.ValidationError: 2 validation errors for CouponResponse 
amount_cents
  none is not an allowed value (type=type_error.none.not_allowed)
amount_currency
  none is not an allowed value (type=type_error.none.not_allowed)
```
