### PR TITLE
fix: applying coupons with percentage discount

### DIFF
--- a/lago_python_client/models/applied_coupon.py
+++ b/lago_python_client/models/applied_coupon.py
@@ -23,9 +23,9 @@ class AppliedCouponResponse(BaseResponseModel):
     status: Optional[str]
     external_customer_id: str
     lago_customer_id: str
-    amount_cents: int
+    amount_cents: Optional[int]
     amount_cents_remaining: Optional[int]
-    amount_currency: str
+    amount_currency: Optional[str]
     expiration_date: Optional[str]
     created_at: str
     terminated_at: Optional[str]


### PR DESCRIPTION
Applying coupons with percentage discount raises the error

```
pydantic.error_wrappers.ValidationError: 2 validation errors for AppliedCouponResponse 
amount_cents
  none is not an allowed value (type=type_error.none.not_allowed)
amount_currency
  none is not an allowed value (type=type_error.none.not_allowed)
```