### PR TITLE
fix: correct field name from `lago_item_id` to `lago_id`

### DIFF
--- a/lago_python_client/models/invoice_item.py
+++ b/lago_python_client/models/invoice_item.py
@@ -8,4 +8,5 @@ class InvoiceItemResponse(BaseResponseModel):
     code: Optional[str]
     name: Optional[str]
     lago_id: Optional[str]
+    lago_item_id: Optional[str]
     item_type: Optional[str]

--- a/lago_python_client/models/invoice_item.py
+++ b/lago_python_client/models/invoice_item.py
@@ -7,5 +7,5 @@ class InvoiceItemResponse(BaseResponseModel):
     type: Optional[str]
     code: Optional[str]
     name: Optional[str]
-    lago_item_id: Optional[str]
+    lago_id: Optional[str]
     item_type: Optional[str]


### PR DESCRIPTION
`InvoiceItemResponse` model defines a field `lago_item_id` which is not returned on API. The correct field is `lago_id`

