### PR TITLE
feat: add httpx Timeout optional parameter

### DIFF
--- a/lago_python_client/mixins.py
+++ b/lago_python_client/mixins.py
@@ -1,5 +1,8 @@
 import sys
 from typing import Any, Generic, Optional, Type, TypeVar, Union
+
+import httpx
+
 try:
     from typing import Protocol
 except ImportError:  # Python 3.7
@@ -36,7 +39,7 @@ class _ClientMixin(Protocol[_PM]):
 class CreateCommandMixin(Generic[_M]):
     """Client mixin with `create` command."""
 
-    def create(self: _ClientMixin[_M], input_object: BaseModel) -> Optional[_M]:
+    def create(self: _ClientMixin[_M], input_object: BaseModel, timeout: Optional[httpx.Timeout] = None) -> Optional[_M]:
         """Execute `create` command."""
         # Send request and save response
         api_response: Response = send_post_request(
@@ -48,6 +51,7 @@ class CreateCommandMixin(Generic[_M]):
                 self.ROOT_NAME: input_object.dict(),
             }),
             headers=make_headers(api_key=self.api_key),
+            timeout=timeout,
         )
 
         # Process response data
@@ -64,7 +68,7 @@ class CreateCommandMixin(Generic[_M]):
 class DestroyCommandMixin(Generic[_M]):
     """Client mixin with `destroy` command."""
 
-    def destroy(self: _ClientMixin[_M], resource_id: str, options: Mapping[str, Union[int, str]] = {}) -> BaseModel:
+    def destroy(self: _ClientMixin[_M], resource_id: str, options: Mapping[str, Union[int, str]] = {}, timeout: Optional[httpx.Timeout] = None) -> BaseModel:
         """Execute `destroy` command."""
         # Send request and save response
         api_response: Response = send_delete_request(
@@ -74,6 +78,7 @@ class DestroyCommandMixin(Generic[_M]):
                 query_pairs=options,
             ),
             headers=make_headers(api_key=self.api_key),
+            timeout=timeout,
         )
 
         # Process response data
@@ -86,7 +91,7 @@ class DestroyCommandMixin(Generic[_M]):
 class FindAllCommandMixin(Generic[_M]):
     """Client mixin with `find_all` command."""
 
-    def find_all(self: _ClientMixin[_M], options: Mapping[str, Union[int, str]] = {}) -> Mapping[str, Any]:
+    def find_all(self: _ClientMixin[_M], options: Mapping[str, Union[int, str]] = {}, timeout: Optional[httpx.Timeout] = None) -> Mapping[str, Any]:
         """Execute `find all` command."""
         # Send request and save response
         api_response: Response = send_get_request(
@@ -96,6 +101,7 @@ class FindAllCommandMixin(Generic[_M]):
                 query_pairs=options,
             ),
             headers=make_headers(api_key=self.api_key),
+            timeout=timeout,
         )
 
         # Process response data
@@ -109,7 +115,7 @@ class FindAllCommandMixin(Generic[_M]):
 class FindCommandMixin(Generic[_M]):
     """Client mixin with `find` command."""
 
-    def find(self: _ClientMixin[_M], resource_id: str, params: Mapping[str, str] = {}) -> _M:
+    def find(self: _ClientMixin[_M], resource_id: str, params: Mapping[str, str] = {}, timeout: Optional[httpx.Timeout] = None) -> _M:
         """Execute `find` command."""
         # Send request and save response
         api_response: Response = send_get_request(
@@ -119,6 +125,7 @@ class FindCommandMixin(Generic[_M]):
                 query_pairs=params,
             ),
             headers=make_headers(api_key=self.api_key),
+            timeout=timeout,
         )
 
         # Process response data
@@ -131,7 +138,7 @@ class FindCommandMixin(Generic[_M]):
 class UpdateCommandMixin(Generic[_M]):
     """Client mixin with `update` command."""
 
-    def update(self: _ClientMixin[_M], input_object: BaseModel, identifier: Optional[str] = None) -> _M:
+    def update(self: _ClientMixin[_M], input_object: BaseModel, identifier: Optional[str] = None, timeout: Optional[httpx.Timeout] = None) -> _M:
         """Execute `update` command."""
         # Send request and save response
         api_response: Response = send_put_request(
@@ -143,6 +150,7 @@ class UpdateCommandMixin(Generic[_M]):
                 self.ROOT_NAME: input_object.dict(exclude_none=True),
             }),
             headers=make_headers(api_key=self.api_key),
+            timeout=timeout,
         )
 
         # Process response data


### PR DESCRIPTION
Add httpx timeout to request mixins (`create`, `destroy`, `find_all`, `find`, `update`)

Usage:

```
from httpx import Timeout

client = Client(api_key='__YOUR_API_KEY__')
client.invoices.find_all({'per_page': 2, 'page': 1}, timeout=Timeout(30))
```

Use case: 

Since there is no ability to exclude zero amount invoices when fetching, the number may be large for a particular date range. This causes a `ReadTimout` exception to occur when the request takes more than 5 seconds [which is the default for httpx](https://github.com/encode/httpx/blob/master/httpx/_config.py#L367)
