### PR TITLE
fix(coupon): Add missing coupons#terminated_at

### DIFF
--- a/lago_python_client/models/coupon.py
+++ b/lago_python_client/models/coupon.py
@@ -36,6 +36,7 @@ class CouponResponse(BaseResponseModel):
     created_at: str
     expiration: str
     expiration_at: Optional[str]
+    terminated_at: Optional[str]
     percentage_rate: Optional[float]
     coupon_type: Optional[str]
     reusable: Optional[bool]

--- a/tests/fixtures/coupon.json
+++ b/tests/fixtures/coupon.json
@@ -17,6 +17,7 @@
     "limited_billable_metrics": false,
     "plan_codes": ["plan1"],
     "billable_metric_codes": [],
-    "created_at": "2022-04-29T08:59:51Z"
+    "created_at": "2022-04-29T08:59:51Z",
+    "terminated_at": "2022-08-08T23:59:59Z"
   }
 }

--- a/tests/fixtures/coupon_index.json
+++ b/tests/fixtures/coupon_index.json
@@ -17,7 +17,8 @@
       "limited_billable_metrics": false,
       "plan_codes": ["plan1"],
       "billable_metric_codes": [],
-      "created_at": "2022-04-29T08:59:51Z"
+      "created_at": "2022-04-29T08:59:51Z",
+      "terminated_at": "2022-08-08T23:59:59Z"
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1222",
@@ -36,7 +37,8 @@
       "limited_billable_metrics": false,
       "plan_codes": ["plan1"],
       "billable_metric_codes": [],
-      "created_at": "2022-04-29T08:59:51Z"
+      "created_at": "2022-04-29T08:59:51Z",
+      "terminated_at": null
     }
   ],
   "meta": {


### PR DESCRIPTION
## Context

Call to `GET /v1/api/coupons/:code` is missing the `terminated_at` value

## Description

This PR is adding the missing field in the `V1::CouponSerializer`