### PR TITLE
feat(invoice_display_name): Add invoice display name

### DIFF
--- a/lago_python_client/models/add_on.py
+++ b/lago_python_client/models/add_on.py
@@ -8,6 +8,7 @@ from .tax import TaxesResponse
 
 class AddOn(BaseModel):
     name: Optional[str]
+    invoice_display_name: Optional[str]
     code: Optional[str]
     amount_cents: Optional[int]
     amount_currency: Optional[str]
@@ -18,6 +19,7 @@ class AddOn(BaseModel):
 class AddOnResponse(BaseResponseModel):
     lago_id: str
     name: str
+    invoice_display_name: Optional[str]
     code: str
     amount_cents: int
     amount_currency: str

--- a/lago_python_client/models/charge.py
+++ b/lago_python_client/models/charge.py
@@ -9,6 +9,7 @@ from ..base_model import BaseResponseModel
 class GroupProperties(BaseModel):
     group_id: Optional[str]
     values: Optional[Dict[str, Any]]
+    invoice_display_name: Optional[str]
 
 
 class GroupPropertiesList(BaseModel):
@@ -22,6 +23,7 @@ class Charge(BaseModel):
     pay_in_advance: Optional[bool]
     prorated: Optional[bool]
     invoiceable: Optional[bool]
+    invoice_display_name: Optional[str]
     min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
     group_properties: Optional[GroupPropertiesList]
@@ -40,6 +42,7 @@ class ChargeResponse(BaseResponseModel):
     pay_in_advance: Optional[bool]
     prorated: Optional[bool]
     invoiceable: Optional[bool]
+    invoice_display_name: Optional[str]
     min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
     group_properties: Optional[GroupPropertiesList]

--- a/lago_python_client/models/fee.py
+++ b/lago_python_client/models/fee.py
@@ -5,6 +5,7 @@ from ..base_model import BaseModel, BaseResponseModel
 
 class Fee(BaseModel):
     payment_status: Optional[str]
+    invoice_display_name: Optional[str]
 
 
 class FeeAppliedTax(BaseResponseModel):
@@ -45,6 +46,7 @@ class FeeResponse(BaseResponseModel):
     description: Optional[str]
     pay_in_advance: Optional[bool]
     invoiceable: Optional[bool]
+    invoice_display_name: Optional[str]
     succeeded_at: Optional[str]
     failed_at: Optional[str]
     refunded_at: Optional[str]

--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -25,6 +25,7 @@ class InvoiceFee(BaseModel):
     unit_amount_cents: Optional[int]
     units: Optional[float]
     description: Optional[str]
+    invoice_display_name: Optional[str]
     tax_codes: Optional[List[str]]
 
 

--- a/lago_python_client/models/invoice_item.py
+++ b/lago_python_client/models/invoice_item.py
@@ -8,5 +8,6 @@ class InvoiceItemResponse(BaseResponseModel):
     code: Optional[str]
     name: Optional[str]
     lago_id: Optional[str]
+    invoice_display_name: Optional[str]
     lago_item_id: Optional[str]
     item_type: Optional[str]

--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -9,6 +9,7 @@ from ..base_model import BaseResponseModel
 
 class Plan(BaseModel):
     name: Optional[str]
+    invoice_display_name: Optional[str]
     code: Optional[str]
     interval: Optional[str]
     description: Optional[str]
@@ -24,6 +25,7 @@ class Plan(BaseModel):
 class PlanResponse(BaseResponseModel):
     lago_id: str
     name: str
+    invoice_display_name: Optional[str]
     created_at: str
     code: str
     interval: Optional[str]

--- a/tests/fixtures/add_on.json
+++ b/tests/fixtures/add_on.json
@@ -2,6 +2,7 @@
   "add_on": {
     "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "name": "add_on_name",
+    "invoice_display_name": "add_on_invoice_display_name",
     "code": "add_on_code",
     "amount_cents": 5000,
     "amount_currency": "USD",

--- a/tests/fixtures/add_on_index.json
+++ b/tests/fixtures/add_on_index.json
@@ -3,6 +3,7 @@
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1111",
       "name": "add_on_name",
+      "invoice_display_name": "add_on_invoice_display_name",
       "code": "add_on_code",
       "amount_cents": 5000,
       "amount_currency": "USD",
@@ -12,6 +13,7 @@
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1222",
       "name": "add_on_name",
+      "invoice_display_name": "add_on_invoice_display_name",
       "code": "add_on_code",
       "amount_cents": 7000,
       "amount_currency": "USD",

--- a/tests/fixtures/credit_note.json
+++ b/tests/fixtures/credit_note.json
@@ -24,10 +24,12 @@
         "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
         "fee": {
           "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+          "invoice_display_name": "credit_note_invoice_display_name",
           "item": {
             "type": "charge",
             "code": "seats",
-            "name": "User Seats"
+            "name": "User Seats",
+            "invoice_display_name": "credit_note_invoice_display_name"
           },
           "credit_amount_cents": 100,
           "credit_amount_currency": "EUR",

--- a/tests/fixtures/customer_usage.json
+++ b/tests/fixtures/customer_usage.json
@@ -16,7 +16,8 @@
         "amount_currency": "EUR",
         "charge": {
           "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
-          "charge_model": "graduated"
+          "charge_model": "graduated",
+          "invoice_display_name": "add_on_invoice_display_name"
         },
         "billable_metric": {
           "lago_id": "99a6094e-199b-4101-896a-54e927ce7bd7",

--- a/tests/fixtures/fee.json
+++ b/tests/fixtures/fee.json
@@ -5,10 +5,12 @@
     "lago_invoice_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "lago_true_up_fee_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "lago_true_up_parent_fee_id": null,
+    "invoice_display_name": "fee_invoice_display_name",
     "item": {
       "type": "charge",
       "code": "fee_code",
-      "name": "Fee Code"
+      "name": "Fee Code",
+      "invoice_display_name": "charge_invoice_display_name"
     },
     "amount_cents": 120,
     "amount_currency": "EUR",

--- a/tests/fixtures/fees.json
+++ b/tests/fixtures/fees.json
@@ -6,10 +6,12 @@
       "lago_invoice_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
       "lago_true_up_fee_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
       "lago_true_up_parent_fee_id": null,
+      "invoice_display_name": "fee_invoice_display_name",
       "item": {
         "type": "instant_charge",
         "code": "fee_code",
-        "name": "Fee Code"
+        "name": "Fee Code",
+        "invoice_display_name": "charge_invoice_display_name"
       },
       "amount_cents": 120,
       "amount_currency": "EUR",

--- a/tests/fixtures/graduated_plan.json
+++ b/tests/fixtures/graduated_plan.json
@@ -2,6 +2,7 @@
   "plan": {
     "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "name": "test1",
+    "invoice_display_name": "test plan 1",
     "created_at": "2022-07-01T14:47:14Z",
     "code": "plan_code",
     "interval": "weekly",

--- a/tests/fixtures/invoice.json
+++ b/tests/fixtures/invoice.json
@@ -103,10 +103,12 @@
     "fees": [
       {
         "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        "invoice_display_name": "fee_invoice_display_name",
         "item": {
           "type": "charge",
           "code": "seats",
-          "name": "User Seats"
+          "name": "User Seats",
+          "invoice_display_name": "charge_invoice_display_name"
         },
         "amount_cents": 100,
         "amount_currency": "EUR",

--- a/tests/fixtures/one_off_invoice.json
+++ b/tests/fixtures/one_off_invoice.json
@@ -88,10 +88,12 @@
     "fees": [
       {
         "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        "invoice_display_name": "fee_invoice_display_name",
         "item": {
           "type": "one_off",
           "code": "one",
-          "name": "Name"
+          "name": "Name",
+          "invoice_display_name": "one_off_invoice_display_name"
         },
         "amount_cents": 100,
         "amount_currency": "EUR",

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -2,6 +2,7 @@
   "plan": {
     "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "name": "test1",
+    "invoice_display_name": "test plan 1",
     "created_at": "2022-07-01T14:47:14Z",
     "code": "plan_code",
     "interval": "weekly",

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -25,6 +25,7 @@
         "charge_model": "standard",
         "pay_in_advance": true,
         "invoiceable": true,
+        "invoice_display_name": "Setup",
         "min_amount_cents": 0,
         "properties": {
           "amount": "0.22"

--- a/tests/fixtures/plan_index.json
+++ b/tests/fixtures/plan_index.json
@@ -3,6 +3,7 @@
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1111",
       "name": "test1",
+      "invoice_display_name": "test plan 1",
       "created_at": "2022-07-01T14:47:14Z",
       "code": "plan_api4",
       "interval": "weekly",
@@ -28,7 +29,8 @@
           "group_properties": [
             {
               "group_id": "gfc1e851-5be6-4343-a0ee-39a81d8b4ee1",
-              "values": { "amount": "0.22" }
+              "values": { "amount": "0.22" },
+              "invoice_display_name": "Europe"
             }
           ]
         }

--- a/tests/test_add_on_client.py
+++ b/tests/test_add_on_client.py
@@ -11,6 +11,7 @@ from lago_python_client.models.add_on import AddOn
 def add_on_object():
     return AddOn(
         name='name',
+        invoice_display_name='add_on_invoice_display_name',
         code='add_on_first',
         amount_cents=1000,
         amount_currency='EUR',
@@ -42,6 +43,7 @@ def test_valid_create_add_on_request(httpx_mock: HTTPXMock):
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'add_on_code'
+    assert response.invoice_display_name == 'add_on_invoice_display_name'
 
 
 def test_invalid_create_add_on_request(httpx_mock: HTTPXMock):
@@ -56,12 +58,14 @@ def test_invalid_create_add_on_request(httpx_mock: HTTPXMock):
 def test_valid_update_add_on_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
     code = 'add_on_code'
+    invoice_display_name = 'add_on_invoice_display_name'
 
     httpx_mock.add_response(method='PUT', url='https://api.getlago.com/api/v1/add_ons/' + code, content=mock_response())
     response = client.add_ons.update(add_on_object(), code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
+    assert response.invoice_display_name == invoice_display_name
 
 
 def test_invalid_update_add_on_request(httpx_mock: HTTPXMock):
@@ -77,12 +81,15 @@ def test_invalid_update_add_on_request(httpx_mock: HTTPXMock):
 def test_valid_find_add_on_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
     code = 'add_on_code'
+    invoice_display_name = 'add_on_invoice_display_name'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/add_ons/' + code, content=mock_response())
     response = client.add_ons.find(code)
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
+    assert response.invoice_display_name == invoice_display_name
+
 
 
 def test_invalid_find_add_on_request(httpx_mock: HTTPXMock):

--- a/tests/test_fee_client.py
+++ b/tests/test_fee_client.py
@@ -16,8 +16,12 @@ def mock_response():
 def test_valid_find_fee_request(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
     identifier = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+    fee_invoice_display_name = 'fee_invoice_display_name'
+    charge_invoice_display_name = 'charge_invoice_display_name'
 
     httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/fees/' + identifier, content=mock_response())
     response = client.fees.find(identifier)
 
     assert response.lago_id == identifier
+    assert response.invoice_display_name == fee_invoice_display_name
+    assert response.item.invoice_display_name == charge_invoice_display_name

--- a/tests/test_invoice_client.py
+++ b/tests/test_invoice_client.py
@@ -52,6 +52,8 @@ def test_valid_create_invoice_request(httpx_mock: HTTPXMock):
 
     assert response.lago_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
     assert response.invoice_type == 'one_off'
+    assert response.fees.__root__[0].invoice_display_name == 'fee_invoice_display_name'
+    assert response.fees.__root__[0].item.invoice_display_name == 'one_off_invoice_display_name'
 
 
 def test_invalid_create_invoice_request(httpx_mock: HTTPXMock):

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -22,7 +22,8 @@ def plan_object():
                 'group_id': 'id',
                 'values': {
                     'amount': '0.22'
-                }
+                },
+                'invoice_display_name': 'Europe'
             }
         ]
     )
@@ -30,6 +31,7 @@ def plan_object():
 
     return Plan(
         name='name',
+        invoice_display_name='invoice_display_name',
         code='code_first',
         amount_cents=1000,
         amount_currency='EUR',
@@ -109,6 +111,7 @@ def test_valid_create_plan_request(httpx_mock: HTTPXMock):
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'plan_code'
+    assert response.invoice_display_name == 'test plan 1'
 
 
 def test_valid_create_graduated_plan_request(httpx_mock: HTTPXMock):
@@ -119,6 +122,7 @@ def test_valid_create_graduated_plan_request(httpx_mock: HTTPXMock):
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'plan_code'
+    assert response.invoice_display_name == 'test plan 1'
 
 
 def test_invalid_create_plan_request(httpx_mock: HTTPXMock):
@@ -139,6 +143,7 @@ def test_valid_update_plan_request(httpx_mock: HTTPXMock):
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
+    assert response.invoice_display_name == 'test plan 1'
 
 
 def test_invalid_update_plan_request(httpx_mock: HTTPXMock):
@@ -160,6 +165,7 @@ def test_valid_find_plan_request(httpx_mock: HTTPXMock):
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
+    assert response.invoice_display_name == 'test plan 1'
     assert response.charges.__root__[0].charge_model == 'standard'
     assert response.charges.__root__[0].min_amount_cents == 0
 
@@ -202,9 +208,11 @@ def test_valid_find_all_plan_request(httpx_mock: HTTPXMock):
     response = client.plans.find_all()
 
     assert response['plans'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
+    assert response['plans'][0].invoice_display_name == 'test plan 1'
     assert response['plans'][0].charges.__root__[0].lago_id == '51c1e851-5be6-4343-a0ee-39a81d8b4ee1'
     assert response['plans'][0].charges.__root__[0].group_properties.__root__[0].group_id == 'gfc1e851-5be6-4343-a0ee-39a81d8b4ee1'
     assert response['plans'][0].charges.__root__[0].group_properties.__root__[0].values['amount'] == '0.22'
+    assert response['plans'][0].charges.__root__[0].group_properties.__root__[0].invoice_display_name == 'Europe'
     assert response['meta']['current_page'] == 1
 
 

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -112,6 +112,7 @@ def test_valid_create_plan_request(httpx_mock: HTTPXMock):
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == 'plan_code'
     assert response.invoice_display_name == 'test plan 1'
+    assert response.charges.__root__[0].invoice_display_name == 'Setup'
 
 
 def test_valid_create_graduated_plan_request(httpx_mock: HTTPXMock):


### PR DESCRIPTION
## Context

Add a custom name to display on invoice for subscription fee and charges

## Description

When generating an invoice, don't display the name of the plan or the name of the billable metrics to the customer.