### PR TITLE
feat(override-plan): Ability to fetch a single subscription

### DIFF
--- a/lago_python_client/subscriptions/clients.py
+++ b/lago_python_client/subscriptions/clients.py
@@ -1,7 +1,7 @@
 from typing import ClassVar, Type
 
 from ..base_client import BaseClient
-from ..mixins import CreateCommandMixin, DestroyCommandMixin, FindAllCommandMixin, UpdateCommandMixin
+from ..mixins import CreateCommandMixin, DestroyCommandMixin, FindAllCommandMixin, FindCommandMixin, UpdateCommandMixin
 from ..models.subscription import SubscriptionResponse
 
 
@@ -9,6 +9,7 @@ class SubscriptionClient(
     CreateCommandMixin[SubscriptionResponse],
     DestroyCommandMixin[SubscriptionResponse],
     FindAllCommandMixin[SubscriptionResponse],
+    FindCommandMixin[SubscriptionResponse],
     UpdateCommandMixin[SubscriptionResponse],
     BaseClient,
 ):

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -112,6 +112,25 @@ def test_invalid_destroy_subscription_request(httpx_mock: HTTPXMock):
     with pytest.raises(LagoApiError):
         client.subscriptions.destroy(identifier)
 
+def test_valid_find_subscription_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')
+    external_id = '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+
+    httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/subscriptions/' + external_id, content=mock_response())
+    response = client.subscriptions.find(external_id)
+
+    assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
+    assert response.external_customer_id == '5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba'
+
+
+def test_invalid_find_subscription_request(httpx_mock: HTTPXMock):
+    client = Client(api_key='invalid')
+    external_id = 'invalid'
+
+    httpx_mock.add_response(method='GET', url='https://api.getlago.com/api/v1/subscriptions/' + external_id, status_code=404, content=b'')
+
+    with pytest.raises(LagoApiError):
+        client.subscriptions.find(external_id)
 
 def test_valid_find_all_subscription_request_with_options(httpx_mock: HTTPXMock):
     client = Client(api_key='886fe239-927d-4072-ab72-6dd345e8dd0d')


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to add the endpoint `GET /api/v1/subscriptions/:external_id`.