### PR TITLE
feat(grouped-by): Add new fields

### DIFF
--- a/lago_python_client/models/customer_usage.py
+++ b/lago_python_client/models/customer_usage.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -23,6 +23,12 @@ class ChargeObject(BaseModel):
     charge_model: str
     invoice_display_name: Optional[str]
 
+class GroupedUsage(BaseModel):
+    amount_cents: int
+    events_count: int
+    units: float
+    grouped_by: Dict[str, str]
+    groups: List[Group]
 
 class ChargeUsage(BaseModel):
     units: float
@@ -32,6 +38,7 @@ class ChargeUsage(BaseModel):
     charge: ChargeObject
     billable_metric: Metric
     groups: List[Group]
+    grouped_usage: Optional[List[GroupedUsage]]
 
 
 class CustomerUsageResponse(BaseResponseModel):

--- a/lago_python_client/models/invoice_item.py
+++ b/lago_python_client/models/invoice_item.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from ..base_model import BaseResponseModel
 
@@ -12,3 +12,4 @@ class InvoiceItemResponse(BaseResponseModel):
     group_invoice_display_name: Optional[str]
     lago_item_id: Optional[str]
     item_type: Optional[str]
+    grouped_by: Optional[Dict[str, str]]

--- a/tests/fixtures/customer_usage.json
+++ b/tests/fixtures/customer_usage.json
@@ -34,6 +34,26 @@
             "events_count": 1,
             "amount_cents": 123
           }
+        ],
+        "grouped_usage": [
+          {
+            "amount_cents": 123,
+            "events_count": 1,
+            "units": "3.0",
+            "grouped_by": {
+              "agent_name": "aragorn"
+            },
+            "groups": [
+              {
+                "lago_id": "12435687-1de8-4428-9bcd-779314ac1111",
+                "key": "google",
+                "value": "europe",
+                "units": "3.0",
+                "events_count": 1,
+                "amount_cents": 123
+              }
+            ]
+          }
         ]
       }
     ]

--- a/tests/fixtures/fee.json
+++ b/tests/fixtures/fee.json
@@ -10,7 +10,10 @@
       "type": "charge",
       "code": "fee_code",
       "name": "Fee Code",
-      "invoice_display_name": "charge_invoice_display_name"
+      "invoice_display_name": "charge_invoice_display_name",
+      "grouped_by": {
+        "agent_name": "aragorn"
+      }
     },
     "amount_cents": 120,
     "amount_currency": "EUR",

--- a/tests/fixtures/fees.json
+++ b/tests/fixtures/fees.json
@@ -11,7 +11,10 @@
         "type": "instant_charge",
         "code": "fee_code",
         "name": "Fee Code",
-        "invoice_display_name": "charge_invoice_display_name"
+        "invoice_display_name": "charge_invoice_display_name",
+        "grouped_by": {
+          "agent_name": "aragorn"
+        }
       },
       "amount_cents": 120,
       "amount_currency": "EUR",

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -28,7 +28,10 @@
         "invoice_display_name": "Setup",
         "min_amount_cents": 0,
         "properties": {
-          "amount": "0.22"
+          "amount": "0.22",
+          "grouped_by": [
+            "agent_name"
+          ]
         },
         "taxes": [
           {


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds all the new fields related to the feature
