### PR TITLE
feat: add support for Pydantic V2

### DIFF
--- a/lago_python_client/base_client.py
+++ b/lago_python_client/base_client.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Type
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 
 class BaseClient(ABC):

--- a/lago_python_client/base_model.py
+++ b/lago_python_client/base_model.py
@@ -1,4 +1,7 @@
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel  # type: ignore
+except ImportError:
+    from pydantic import BaseModel
 
 
 class BaseResponseModel(BaseModel):

--- a/lago_python_client/events/clients.py
+++ b/lago_python_client/events/clients.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Any, ClassVar, Optional, Type
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_client import BaseClient
 from ..fees.clients import FeeClient

--- a/lago_python_client/mixins.py
+++ b/lago_python_client/mixins.py
@@ -8,7 +8,7 @@ try:
 except ImportError:  # Python 3.7
     from typing_extensions import Protocol  # type: ignore
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from .services.json import to_json
 from .services.request import make_headers, make_url, send_delete_request, send_get_request, send_post_request, send_put_request

--- a/lago_python_client/models/add_on.py
+++ b/lago_python_client/models/add_on.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/applied_coupon.py
+++ b/lago_python_client/models/applied_coupon.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from .credit import CreditsResponse
 from ..base_model import BaseResponseModel

--- a/lago_python_client/models/billable_metric.py
+++ b/lago_python_client/models/billable_metric.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/charge.py
+++ b/lago_python_client/models/charge.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from .tax import TaxesResponse
 from ..base_model import BaseResponseModel

--- a/lago_python_client/models/coupon.py
+++ b/lago_python_client/models/coupon.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/credit.py
+++ b/lago_python_client/models/credit.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from .invoice_item import InvoiceItemResponse
 from ..base_model import BaseResponseModel

--- a/lago_python_client/models/credit_note.py
+++ b/lago_python_client/models/credit_note.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from .fee import FeeResponse
 from ..base_model import BaseResponseModel

--- a/lago_python_client/models/customer.py
+++ b/lago_python_client/models/customer.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/customer_usage.py
+++ b/lago_python_client/models/customer_usage.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/event.py
+++ b/lago_python_client/models/event.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/group.py
+++ b/lago_python_client/models/group.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from .credit import CreditsResponse
 from .customer import CustomerResponse

--- a/lago_python_client/models/organization.py
+++ b/lago_python_client/models/organization.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from .charge import Charges, ChargesResponse, ChargesOverrides
 from .tax import Taxes, TaxesResponse

--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 from .plan import PlanOverrides
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/tax.py
+++ b/lago_python_client/models/tax.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/wallet_transaction.py
+++ b/lago_python_client/models/wallet_transaction.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/models/webhook_endpoint.py
+++ b/lago_python_client/models/webhook_endpoint.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_model import BaseResponseModel
 

--- a/lago_python_client/services/response.py
+++ b/lago_python_client/services/response.py
@@ -11,7 +11,7 @@ except ImportError:  # Python 3.7
     from typing_extensions import Final  # type: ignore
 
 from httpx import Response as Response  # not a typo! implicit reexport
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 import typeguard
 
 from ..exceptions import LagoApiError

--- a/lago_python_client/wallets/clients.py
+++ b/lago_python_client/wallets/clients.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Any, ClassVar, Type, Union
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_client import BaseClient
 from ..mixins import CreateCommandMixin, DestroyCommandMixin, FindAllCommandMixin, FindCommandMixin, UpdateCommandMixin

--- a/lago_python_client/webhook_endpoints/clients.py
+++ b/lago_python_client/webhook_endpoints/clients.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Any, ClassVar, Type, Union
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 
 from ..base_client import BaseClient
 from ..mixins import CreateCommandMixin, DestroyCommandMixin, FindAllCommandMixin, FindCommandMixin, UpdateCommandMixin

--- a/lago_python_client/webhooks/clients.py
+++ b/lago_python_client/webhooks/clients.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from typing_extensions import TypedDict
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 import typeguard
 
 from ..base_client import BaseClient

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     classes~=0.4.1  # bugfix auto updates allowed
     httpx~=0.24.0  # bugfix auto updates allowed
     orjson~=3.8  # minor auto updates allowed
-    pydantic~=1.10  # minor auto updates allowed
+    pydantic>=1.10,<3 # minor auto updates allowed
     typeguard~=3.0.2  # bugfix auto updates allowed
 
 [options.extras_require]

--- a/tests/test_response_services.py
+++ b/tests/test_response_services.py
@@ -1,7 +1,7 @@
 """Test response services."""
 from copy import deepcopy
 
-from pydantic import BaseModel
+from lago_python_client.base_model import BaseModel
 import pytest
 from httpx import Request, Response
 


### PR DESCRIPTION
# Description

As it stands, any project using `lago-python-client` can't upgrade to Pydantic V2 due to version constraints. Fortunately for us, Pydantic V2 ships with V1 to allow for incremental adoption, which allows us to support both V1 and V2 without fundamentally changing the package's code:
```python
try:
    from pydantic.v1 import BaseModel 
except ImportError:
    from pydantic import BaseModel
```

In addition to this, I changed all the `from pydantic import BaseModel` imports to pull from `base_model` instead.

## Type of Change
Feature - non-breaking change

# Testing
Used `pytest` to run the tests once for each version. To replicate:
1. Install the project's base dependencies (in a virtualenv ideally).
```bash
pip install -e .
```
2. Install Pydantic V1.
```bash
pip install pydantic==1.10
```
3. Run pytest.
```bash
pytest
```
4. Install Pydantic V2.
```bash
pip uninstall pydantic && pip install pydantic==2.6.1
```
5. Run pytest again.
```bash
pytest
```