### PR TITLE
feat(filter): Add filter fields

### DIFF
--- a/lago_python_client/models/billable_metric.py
+++ b/lago_python_client/models/billable_metric.py
@@ -10,6 +10,15 @@ class BillableMetricGroup(BaseModel):
     values: Optional[List[Union[str, Dict[str, Any]]]]
 
 
+class BillableMetricFilter(BaseModel):
+    key: Optional[str]
+    values: Optional[List[str]]
+
+
+class BillableMetricFilters(BaseModel):
+    __root__: List[BillableMetricFilter]
+
+
 class BillableMetric(BaseModel):
     name: Optional[str]
     code: Optional[str]
@@ -19,6 +28,7 @@ class BillableMetric(BaseModel):
     weighted_interval: Optional[str]
     field_name: Optional[str]
     group: Optional[BillableMetricGroup]
+    filters: Optional[BillableMetricFilters]
 
 
 class BillableMetricResponse(BaseResponseModel):
@@ -32,6 +42,7 @@ class BillableMetricResponse(BaseResponseModel):
     field_name: Optional[str]
     created_at: str
     group: BillableMetricGroup
+    filters: BillableMetricFilters
     active_subscriptions_count: int
     draft_invoices_count: int
     plans_count: int

--- a/lago_python_client/models/charge.py
+++ b/lago_python_client/models/charge.py
@@ -16,6 +16,16 @@ class GroupPropertiesList(BaseModel):
     __root__: List[GroupProperties]
 
 
+class ChargeFilter(BaseModel):
+    invoice_display_name: Optional[str]
+    properties: Optional[Dict[str, Any]]
+    values: Optional[Dict[str, List[str]]]
+
+
+class ChargeFilters(BaseModel):
+    __root__: List[ChargeFilter]
+
+
 class Charge(BaseModel):
     id: Optional[str]
     billable_metric_id: Optional[str]
@@ -27,6 +37,7 @@ class Charge(BaseModel):
     min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
     group_properties: Optional[GroupPropertiesList]
+    filters: Optional[ChargeFilters]
     tax_codes: Optional[List[str]]
 
 
@@ -46,6 +57,7 @@ class ChargeResponse(BaseResponseModel):
     min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
     group_properties: Optional[GroupPropertiesList]
+    filters: Optional[ChargeFilters]
     taxes: Optional[TaxesResponse]
 
 
@@ -59,6 +71,7 @@ class ChargeOverrides(BaseModel):
     min_amount_cents: Optional[int]
     properties: Optional[Dict[str, Any]]
     group_properties: Optional[GroupPropertiesList]
+    filters: Optional[ChargeFilters]
     tax_codes: Optional[List[str]]
 
 

--- a/lago_python_client/models/customer_usage.py
+++ b/lago_python_client/models/customer_usage.py
@@ -18,6 +18,15 @@ class Group(BaseModel):
     units: str
     amount_cents: int
 
+
+class ChargeFilterUsage(BaseModel):
+    invoice_display_name: Optional[str]
+    values: Dict[str, List[str]]
+    units: str
+    amount_cents: int
+    events_count: int
+
+
 class ChargeObject(BaseModel):
     lago_id: str
     charge_model: str
@@ -29,6 +38,7 @@ class GroupedUsage(BaseModel):
     units: float
     grouped_by: Dict[str, str]
     groups: List[Group]
+    filters: List[ChargeFilterUsage]
 
 class ChargeUsage(BaseModel):
     units: float
@@ -38,6 +48,7 @@ class ChargeUsage(BaseModel):
     charge: ChargeObject
     billable_metric: Metric
     groups: List[Group]
+    filters: List[ChargeFilterUsage]
     grouped_usage: Optional[List[GroupedUsage]]
 
 

--- a/lago_python_client/models/fee.py
+++ b/lago_python_client/models/fee.py
@@ -28,6 +28,7 @@ class FeeAppliedTaxes(BaseResponseModel):
 class FeeResponse(BaseResponseModel):
     lago_id: Optional[str]
     lago_group_id: Optional[str]
+    lago_charge_filter_id: Optional[str]
     lago_invoice_id: Optional[str]
     lago_true_up_fee_id: Optional[str]
     lago_true_up_parent_fee_id: Optional[str]

--- a/lago_python_client/models/invoice_item.py
+++ b/lago_python_client/models/invoice_item.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from ..base_model import BaseResponseModel
 
@@ -10,6 +10,8 @@ class InvoiceItemResponse(BaseResponseModel):
     lago_id: Optional[str]
     invoice_display_name: Optional[str]
     group_invoice_display_name: Optional[str]
+    filter_invoice_display_name: Optional[str]
+    filters: Optional[Dict[str, List[str]]]
     lago_item_id: Optional[str]
     item_type: Optional[str]
     grouped_by: Optional[Dict[str, str]]

--- a/tests/fixtures/billable_metric.json
+++ b/tests/fixtures/billable_metric.json
@@ -11,8 +11,22 @@
     "created_at": "2022-04-29T08:59:51Z",
     "group": {
       "key": "country",
-      "values": ["france", "italy", "spain"]
+      "values": [
+        "france",
+        "italy",
+        "spain"
+      ]
     },
+    "filters": [
+      {
+        "key": "country",
+        "values": [
+          "france",
+          "italy",
+          "spain"
+        ]
+      }
+    ],
     "active_subscriptions_count": 0,
     "draft_invoices_count": 0,
     "plans_count": 0

--- a/tests/fixtures/billable_metric_index.json
+++ b/tests/fixtures/billable_metric_index.json
@@ -11,6 +11,7 @@
       "field_name": "amount_sum",
       "created_at": "2022-04-29T08:59:51Z",
       "group": {},
+      "filters": [],
       "active_subscriptions_count": 0,
       "draft_invoices_count": 0,
       "plans_count": 0
@@ -26,6 +27,7 @@
       "field_name": "amount_sum",
       "created_at": "2022-04-30T08:59:51Z",
       "group": {},
+      "filters": [],
       "active_subscriptions_count": 0,
       "draft_invoices_count": 0,
       "plans_count": 0

--- a/tests/fixtures/customer_past_usage.json
+++ b/tests/fixtures/customer_past_usage.json
@@ -25,7 +25,19 @@
             "code": "usage_metric",
             "aggregation_type": "sum"
           },
-          "groups": []
+          "groups": [],
+          "filters": [
+            {
+              "units": "3.0",
+              "events_count": 1,
+              "amount_cents": 123,
+              "values": {
+                "country": [
+                  "france"
+                ]
+              }
+            }
+          ]
         }
       ]
     }

--- a/tests/fixtures/customer_usage.json
+++ b/tests/fixtures/customer_usage.json
@@ -35,6 +35,18 @@
             "amount_cents": 123
           }
         ],
+        "filters": [
+          {
+            "units": "3.0",
+            "events_count": 1,
+            "amount_cents": 123,
+            "values": {
+              "country": [
+                "france"
+              ]
+            }
+          }
+        ],
         "grouped_usage": [
           {
             "amount_cents": 123,
@@ -51,6 +63,18 @@
                 "units": "3.0",
                 "events_count": 1,
                 "amount_cents": 123
+              }
+            ],
+            "filters": [
+              {
+                "units": "3.0",
+                "events_count": 1,
+                "amount_cents": 123,
+                "values": {
+                  "country": [
+                    "france"
+                  ]
+                }
               }
             ]
           }

--- a/tests/fixtures/fee.json
+++ b/tests/fixtures/fee.json
@@ -2,6 +2,7 @@
   "fee": {
     "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
     "lago_group_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+    "lago_charge_filter_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "lago_invoice_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "lago_true_up_fee_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
     "lago_true_up_parent_fee_id": null,
@@ -11,6 +12,7 @@
       "code": "fee_code",
       "name": "Fee Code",
       "invoice_display_name": "charge_invoice_display_name",
+      "charge_filter_invoice_display_name": "charge_filter_invoice_display_name",
       "grouped_by": {
         "agent_name": "aragorn"
       }

--- a/tests/fixtures/fees.json
+++ b/tests/fixtures/fees.json
@@ -3,6 +3,7 @@
     {
       "lago_id": "nil",
       "lago_group_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
+      "lago_charge_filter_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
       "lago_invoice_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
       "lago_true_up_fee_id": "1a2d9c8d-5875-4688-9854-5ccfd414bc5e",
       "lago_true_up_parent_fee_id": null,
@@ -12,6 +13,7 @@
         "code": "fee_code",
         "name": "Fee Code",
         "invoice_display_name": "charge_invoice_display_name",
+        "charge_filter_invoice_display_name": "charge_filter_invoice_display_name",
         "grouped_by": {
           "agent_name": "aragorn"
         }

--- a/tests/fixtures/invoice.json
+++ b/tests/fixtures/invoice.json
@@ -109,7 +109,12 @@
           "type": "charge",
           "code": "seats",
           "name": "User Seats",
-          "invoice_display_name": "charge_invoice_display_name"
+          "invoice_display_name": "charge_invoice_display_name",
+          "filters": {
+            "region": [
+              "us-east-1"
+            ]
+          }
         },
         "amount_cents": 100,
         "amount_currency": "EUR",

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -33,6 +33,19 @@
             "agent_name"
           ]
         },
+        "filters": [
+          {
+            "invoice_display_name": "From France",
+            "properties": {
+              "amount": "0.33"
+            },
+            "values": {
+              "country": [
+                "France"
+              ]
+            }
+          }
+        ],
         "taxes": [
           {
             "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR is related to https://github.com/getlago/lago-openapi/pull/210
It adds the new filter fields in both input and output objects