### PR TITLE
feat(minimum-commitment): Add minimum commitment

### DIFF
--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -14,6 +14,7 @@ from .customer import Customer, CustomerBillingConfiguration, Metadata, Metadata
 from .invoice import InvoicePaymentStatusChange, Invoice, InvoiceMetadata, InvoiceMetadataList,\
     OneOffInvoice, InvoiceFeesList, InvoiceFee
 from .invoice_item import InvoiceItemResponse
+from .minimum_commitment import MinimumCommitment, MinimumCommitmentResponse
 from .subscription import Subscription
 from .customer_usage import Metric, ChargeObject, ChargeUsage, CustomerUsageResponse
 from .tax import Tax, Taxes, TaxResponse, TaxesResponse

--- a/lago_python_client/models/minimum_commitment.py
+++ b/lago_python_client/models/minimum_commitment.py
@@ -1,0 +1,28 @@
+from typing import Any, Dict, List, Optional
+
+from lago_python_client.base_model import BaseModel
+
+from .tax import TaxesResponse
+from ..base_model import BaseResponseModel
+
+
+
+class MinimumCommitment(BaseModel):
+    amount_cents: Optional[int]
+    invoice_display_name: Optional[str]
+    tax_codes: Optional[List[str]]
+
+class MinimumCommitmentResponse(BaseResponseModel):
+    lago_id: str
+    amount_cents: int
+    invoice_display_name: Optional[str]
+    interval: str
+    taxes: Optional[TaxesResponse]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+
+
+class MinimumCommitmentOverrides(BaseModel):
+    amount_cents: Optional[int]
+    invoice_display_name: Optional[str]
+    tax_codes: Optional[List[str]]

--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from lago_python_client.base_model import BaseModel
 
 from .charge import Charges, ChargesResponse, ChargesOverrides
+from .minimum_commitment import MinimumCommitment, MinimumCommitmentResponse, MinimumCommitmentOverrides
 from .tax import Taxes, TaxesResponse
 from ..base_model import BaseResponseModel
 
@@ -19,6 +20,7 @@ class Plan(BaseModel):
     pay_in_advance: Optional[bool]
     bill_charges_monthly: Optional[bool]
     charges: Optional[Charges]
+    minimum_commitment: Optional[MinimumCommitment]
     tax_codes: Optional[List[str]]
 
 
@@ -36,6 +38,7 @@ class PlanResponse(BaseResponseModel):
     pay_in_advance: Optional[bool]
     bill_charges_monthly: Optional[bool]
     charges: Optional[ChargesResponse]
+    minimum_commitment: Optional[MinimumCommitmentResponse]
     active_subscriptions_count: int
     draft_invoices_count: int
     taxes: Optional[TaxesResponse]
@@ -48,4 +51,5 @@ class PlanOverrides(BaseModel):
     amount_currency: Optional[str]
     trial_period: Optional[float]
     charges: Optional[ChargesOverrides]
+    minimum_commitment: Optional[MinimumCommitmentOverrides]
     tax_codes: Optional[List[str]]

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -50,6 +50,12 @@
         ]
       }
     ],
+    "minimum_commitment": {
+      "lago_id": "9474537e-2070-44fe-b8ba-3a25e0aa2d8e",
+      "invoice_display_name": "Minimum commitment (C1)",
+      "amount_cents": 1000,
+      "interval": "weekly"
+    },
     "taxes": [
       {
         "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",

--- a/tests/fixtures/plan_index.json
+++ b/tests/fixtures/plan_index.json
@@ -34,7 +34,13 @@
             }
           ]
         }
-      ]
+      ],
+      "minimum_commitment": {
+        "lago_id": "9474537e-2070-44fe-b8ba-3a25e0aa2d8e",
+        "invoice_display_name": "Minimum commitment (C2)",
+        "amount_cents": 1000,
+        "interval": "weekly"
+      }
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1222",

--- a/tests/test_plan_client.py
+++ b/tests/test_plan_client.py
@@ -5,7 +5,7 @@ from pytest_httpx import HTTPXMock
 
 from lago_python_client.client import Client
 from lago_python_client.exceptions import LagoApiError
-from lago_python_client.models import Plan, Charge, Charges
+from lago_python_client.models import Plan, Charge, Charges, MinimumCommitment
 
 
 def plan_object():
@@ -29,6 +29,11 @@ def plan_object():
     )
     charges = Charges(__root__=[charge])
 
+    minimum_commitment = MinimumCommitment(
+        amount_cents=0,
+        invoice_display_name='Commitment (C1)'
+    )
+
     return Plan(
         name='name',
         invoice_display_name='invoice_display_name',
@@ -38,7 +43,8 @@ def plan_object():
         description='desc',
         interval='weekly',
         pay_in_advance=True,
-        charges=charges
+        charges=charges,
+        minimum_commitment=minimum_commitment
     )
 
 
@@ -113,6 +119,7 @@ def test_valid_create_plan_request(httpx_mock: HTTPXMock):
     assert response.code == 'plan_code'
     assert response.invoice_display_name == 'test plan 1'
     assert response.charges.__root__[0].invoice_display_name == 'Setup'
+    assert response.minimum_commitment.invoice_display_name == 'Minimum commitment (C1)'
 
 
 def test_valid_create_graduated_plan_request(httpx_mock: HTTPXMock):
@@ -145,6 +152,7 @@ def test_valid_update_plan_request(httpx_mock: HTTPXMock):
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.code == code
     assert response.invoice_display_name == 'test plan 1'
+    assert response.minimum_commitment.invoice_display_name == 'Minimum commitment (C1)'
 
 
 def test_invalid_update_plan_request(httpx_mock: HTTPXMock):
@@ -169,6 +177,7 @@ def test_valid_find_plan_request(httpx_mock: HTTPXMock):
     assert response.invoice_display_name == 'test plan 1'
     assert response.charges.__root__[0].charge_model == 'standard'
     assert response.charges.__root__[0].min_amount_cents == 0
+    assert response.minimum_commitment.amount_cents == 1000
 
 
 def test_invalid_find_plan_request(httpx_mock: HTTPXMock):
@@ -210,6 +219,7 @@ def test_valid_find_all_plan_request(httpx_mock: HTTPXMock):
 
     assert response['plans'][0].lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac1111'
     assert response['plans'][0].invoice_display_name == 'test plan 1'
+    assert response['plans'][0].minimum_commitment.invoice_display_name == 'Minimum commitment (C2)'
     assert response['plans'][0].charges.__root__[0].lago_id == '51c1e851-5be6-4343-a0ee-39a81d8b4ee1'
     assert response['plans'][0].charges.__root__[0].group_properties.__root__[0].group_id == 'gfc1e851-5be6-4343-a0ee-39a81d8b4ee1'
     assert response['plans'][0].charges.__root__[0].group_properties.__root__[0].values['amount'] == '0.22'


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

This PR adds minimum commitment to plan and plan overrides.