### PR TITLE
fix: mark sequential_id as optional

### DIFF
--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -68,7 +68,7 @@ class InvoiceAppliedTaxes(BaseResponseModel):
 
 class InvoiceResponse(BaseResponseModel):
     lago_id: str
-    sequential_id: int
+    sequential_id: Optional[int]
     number: str
     issuing_date: Optional[str]
     payment_due_date: Optional[str]


### PR DESCRIPTION
Currently, we generate `sequential_id` upon invoice finalization. When the invoice is draft `sequential_id` could be nil.

We have to make this field optional in api response.