### PR TITLE
feat: Add recurring_transaction_rules and items to responses

### DIFF
--- a/tests/fixtures/credit_note_index.json
+++ b/tests/fixtures/credit_note_index.json
@@ -19,7 +19,32 @@
       "sub_total_excluding_taxes_amount_cents": 200,
       "coupons_adjustment_amount_cents": 0,
       "created_at": "2022-10-04 16:21:00",
-      "updated_at": "2022-10-04 16:21:00"
+      "updated_at": "2022-10-04 16:21:00",
+      "items": [
+        {
+          "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+          "fee": {
+            "lago_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+            "invoice_display_name": "credit_note_invoice_display_name",
+            "item": {
+              "type": "charge",
+              "code": "seats",
+              "name": "User Seats",
+              "invoice_display_name": "credit_note_invoice_display_name"
+            },
+            "credit_amount_cents": 100,
+            "credit_amount_currency": "EUR",
+            "refund_amount_cents": 50,
+            "refund_amount_currency": "EUR",
+            "taxes_amount_cents": 20,
+            "taxes_rate": "20.0",
+            "total_amount_cents": 120,
+            "total_amount_currency": "EUR",
+            "units": 12.6,
+            "events_count": 4
+          }
+        }
+      ]
     }
   ],
   "meta": {

--- a/tests/fixtures/wallet_index.json
+++ b/tests/fixtures/wallet_index.json
@@ -19,7 +19,16 @@
       "ongoing_balance_cents": 800,
       "ongoing_usage_balance_cents": 200,
       "credits_ongoing_balance": "8.0",
-      "credits_ongoing_usage_balance": "2.0"
+      "credits_ongoing_usage_balance": "2.0",
+      "recurring_transaction_rules": [
+        {
+          "lago_id": "12345",
+          "rule_type": "interval",
+          "interval": "monthly",
+          "paid_credits": "105.0",
+          "granted_credits": "105.0"
+        }
+      ]
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1111",
@@ -40,7 +49,8 @@
       "ongoing_balance_cents": 800,
       "ongoing_usage_balance_cents": 200,
       "credits_ongoing_balance": "8.0",
-      "credits_ongoing_usage_balance": "2.0"
+      "credits_ongoing_usage_balance": "2.0",
+      "recurring_transaction_rules": []
     }
   ],
   "meta": {


### PR DESCRIPTION
The goal of this PR is to add:
- `items` to `CreditNotesController#index`
- `recurring_transaction_rules` to `WalletsController#index`