### PR TITLE
feat(wallet): Add voided_credits to WalletTransaction

### DIFF
--- a/lago_python_client/models/wallet_transaction.py
+++ b/lago_python_client/models/wallet_transaction.py
@@ -9,6 +9,7 @@ class WalletTransaction(BaseModel):
     wallet_id: Optional[str]
     paid_credits: Optional[str]
     granted_credits: Optional[str]
+    voided_credits: Optional[str]
 
 
 class WalletTransactionResponse(BaseResponseModel):

--- a/tests/test_wallet_transaction_client.py
+++ b/tests/test_wallet_transaction_client.py
@@ -12,7 +12,8 @@ def wallet_transaction_object():
     return WalletTransaction(
         wallet_id='123',
         paid_credits='10',
-        granted_credits='10'
+        granted_credits='10',
+        voided_credits='0'
     )
 
 


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to create a voided wallet transaction.