### PR TITLE
feat(wallet): Rename wallet rule_type into trigger

### DIFF
--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -7,18 +7,18 @@ from ..base_model import BaseResponseModel
 
 class RecurringTransactionRule(BaseModel):
     lago_id: Optional[str]
-    rule_type: Optional[str]
     interval: Optional[str]
     threshold_credits: Optional[str]
+    trigger: Optional[str]
     paid_credits: Optional[str]
     granted_credits: Optional[str]
 
 
 class RecurringTransactionRuleResponse(BaseModel):
     lago_id: Optional[str]
-    rule_type: Optional[str]
     interval: Optional[str]
     threshold_credits: Optional[str]
+    trigger: Optional[str]
     paid_credits: Optional[str]
     granted_credits: Optional[str]
     created_at: Optional[str]

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -18,7 +18,7 @@
     "recurring_transaction_rules": [
       {
         "lago_id": "12345",
-        "rule_type": "interval",
+        "trigger": "interval",
         "interval": "monthly",
         "paid_credits": "105.0",
         "granted_credits": "105.0"

--- a/tests/fixtures/wallet_index.json
+++ b/tests/fixtures/wallet_index.json
@@ -23,7 +23,7 @@
       "recurring_transaction_rules": [
         {
           "lago_id": "12345",
-          "rule_type": "interval",
+          "trigger": "interval",
           "interval": "monthly",
           "paid_credits": "105.0",
           "granted_credits": "105.0"

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -10,7 +10,7 @@ from lago_python_client.models import Wallet, RecurringTransactionRule, Recurrin
 
 def wallet_object():
     rule = RecurringTransactionRule(
-        rule_type='interval',
+        trigger='interval',
         interval='monthly',
         paid_credits='105.0',
         granted_credits='105.0',
@@ -50,7 +50,7 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
 
     assert response.lago_id == 'b7ab2926-1de8-4428-9bcd-779314ac129b'
     assert response.recurring_transaction_rules.__root__[0].lago_id == '12345'
-    assert response.recurring_transaction_rules.__root__[0].rule_type == 'interval'
+    assert response.recurring_transaction_rules.__root__[0].trigger == 'interval'
     assert response.recurring_transaction_rules.__root__[0].interval == 'monthly'
 
 


### PR DESCRIPTION
## Context

After the release of real-time wallet version 1, some customers have expressed concerns about odd or missing behaviors.

## Description

The goal of this PR is to rename `Wallet#rule_type` into `Wallet#trigger`.