### PR TITLE
feat(wallet): Add method and target_ongoing_balance to recurring_transaction_rule

### DIFF
--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -10,8 +10,10 @@ class RecurringTransactionRule(BaseModel):
     interval: Optional[str]
     threshold_credits: Optional[str]
     trigger: Optional[str]
+    method: Optional[str]
     paid_credits: Optional[str]
     granted_credits: Optional[str]
+    target_ongoing_balance: Optional[str]
 
 
 class RecurringTransactionRuleResponse(BaseModel):
@@ -19,8 +21,10 @@ class RecurringTransactionRuleResponse(BaseModel):
     interval: Optional[str]
     threshold_credits: Optional[str]
     trigger: Optional[str]
+    method: Optional[str]
     paid_credits: Optional[str]
     granted_credits: Optional[str]
+    target_ongoing_balance: Optional[str]
     created_at: Optional[str]
 
 

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -19,9 +19,11 @@
       {
         "lago_id": "12345",
         "trigger": "interval",
+        "method": "target",
         "interval": "monthly",
         "paid_credits": "105.0",
-        "granted_credits": "105.0"
+        "granted_credits": "105.0",
+        "target_ongoing_balance": "200.0"
       }
     ],
     "ongoing_balance_cents": 800,

--- a/tests/fixtures/wallet_index.json
+++ b/tests/fixtures/wallet_index.json
@@ -24,9 +24,11 @@
         {
           "lago_id": "12345",
           "trigger": "interval",
+          "method": "fixed",
           "interval": "monthly",
           "paid_credits": "105.0",
-          "granted_credits": "105.0"
+          "granted_credits": "105.0",
+          "target_ongoing_balance": null
         }
       ]
     },

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -14,6 +14,8 @@ def wallet_object():
         interval='monthly',
         paid_credits='105.0',
         granted_credits='105.0',
+        method='target',
+        target_ongoing_balance='105.0'
     )
     rules_list = RecurringTransactionRuleList(__root__=[rule])
     return Wallet(


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to add:

- `method`
- `target_ongoing_balance`

to `recurring_transaction_rule`