### PR TITLE
feat(customers): add support for customer shipping address

### DIFF
--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -11,7 +11,7 @@ from .event import Event, BatchEvent
 from .fee import Fee
 from .customer import Customer, CustomerBillingConfiguration, Metadata, MetadataList,\
     MetadataResponse, MetadataResponseList, IntegrationCustomer, IntegrationCustomerResponse,\
-    IntegrationCustomersResponseList, IntegrationCustomersList
+    IntegrationCustomersResponseList, IntegrationCustomersList, Address
 from .invoice import InvoicePaymentStatusChange, Invoice, InvoiceMetadata, InvoiceMetadataList,\
     OneOffInvoice, InvoiceFeesList, InvoiceFee
 from .invoice_item import InvoiceItemResponse

--- a/lago_python_client/models/customer.py
+++ b/lago_python_client/models/customer.py
@@ -19,7 +19,7 @@ class CustomerBillingConfiguration(BaseModel):
 
 
 class Address(BaseModel):
-    address_line1: Optional[int]
+    address_line1: Optional[str]
     address_line2: Optional[str]
     city: Optional[str]
     zipcode: Optional[str]

--- a/lago_python_client/models/customer.py
+++ b/lago_python_client/models/customer.py
@@ -18,6 +18,15 @@ class CustomerBillingConfiguration(BaseModel):
     provider_payment_methods: Optional[List[str]]
 
 
+class Address(BaseModel):
+    address_line1: Optional[int]
+    address_line2: Optional[str]
+    city: Optional[str]
+    zipcode: Optional[str]
+    state: Optional[str]
+    country: Optional[str]
+
+
 class IntegrationCustomer(BaseModel):
     id: Optional[str]
     external_customer_id: Optional[str]
@@ -87,6 +96,7 @@ class Customer(BaseModel):
     zipcode: Optional[str]
     metadata: Optional[MetadataList]
     billing_configuration: Optional[CustomerBillingConfiguration]
+    shipping_address: Optional[Address]
     integration_customers: Optional[IntegrationCustomersList]
     tax_codes: Optional[List[str]]
 
@@ -116,5 +126,6 @@ class CustomerResponse(BaseResponseModel):
     zipcode: Optional[str]
     metadata: Optional[MetadataResponseList]
     billing_configuration: Optional[CustomerBillingConfiguration]
+    shipping_address: Optional[Address]
     integration_customers: Optional[IntegrationCustomersResponseList]
     taxes: Optional[TaxesResponse]

--- a/tests/fixtures/customer.json
+++ b/tests/fixtures/customer.json
@@ -34,7 +34,10 @@
     "shipping_address": {
       "city": "Paris",
       "zipcode": "123",
-      "country": "FR"
+      "country": "FR",
+      "address_line1": "Test Ave",
+      "address_line2": null,
+      "state": "XZ"
     },
     "integration_customers": [
       {

--- a/tests/fixtures/customer.json
+++ b/tests/fixtures/customer.json
@@ -31,6 +31,11 @@
       "document_locale": "fr",
       "provider_payment_methods": ["card", "sepa_debit"]
     },
+    "shipping_address": {
+      "city": "Paris",
+      "zipcode": "123",
+      "country": "FR"
+    },
     "integration_customers": [
       {
         "lago_id": "123456789",

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -43,7 +43,9 @@ def create_customer():
         shipping_address=Address(
             city='Paris',
             zipcode='123',
-            country='FR'
+            country='FR',
+            address_line1='Test Ave',
+            state='XZ'
 ,       ),
         integration_customers=integration_customers_list,
         metadata=metadata_list
@@ -79,6 +81,9 @@ def test_valid_create_customers_request(httpx_mock: HTTPXMock):
     assert response.shipping_address.city == 'Paris'
     assert response.shipping_address.country == 'FR'
     assert response.shipping_address.zipcode == '123'
+    assert response.shipping_address.address_line1 == 'Test Ave'
+    assert response.shipping_address.address_line2 == None
+    assert response.shipping_address.state == 'XZ'
     assert response.integration_customers.__root__[0].external_customer_id == 'test-12345'
     assert response.integration_customers.__root__[0].type == "netsuite"
     assert response.metadata.__root__[0].lago_id == '12345'

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -6,7 +6,7 @@ from pytest_httpx import HTTPXMock
 from lago_python_client.client import Client
 from lago_python_client.exceptions import LagoApiError
 from lago_python_client.models import Customer, IntegrationCustomer, IntegrationCustomersList,\
-    CustomerBillingConfiguration, Metadata, MetadataList
+    CustomerBillingConfiguration, Metadata, MetadataList, Address
 
 
 def create_customer():
@@ -40,6 +40,11 @@ def create_customer():
             document_locale="fr",
             provider_payment_methods=["card", "sepa_debit"],
         ),
+        shipping_address=Address(
+            city='Paris',
+            zipcode='123',
+            country='FR'
+,       ),
         integration_customers=integration_customers_list,
         metadata=metadata_list
     )
@@ -71,6 +76,9 @@ def test_valid_create_customers_request(httpx_mock: HTTPXMock):
     assert response.billing_configuration.provider_customer_id == 'cus_12345'
     assert response.billing_configuration.sync_with_provider == True
     assert response.billing_configuration.document_locale == "fr"
+    assert response.shipping_address.city == 'Paris'
+    assert response.shipping_address.country == 'FR'
+    assert response.shipping_address.zipcode == '123'
     assert response.integration_customers.__root__[0].external_customer_id == 'test-12345'
     assert response.integration_customers.__root__[0].type == "netsuite"
     assert response.metadata.__root__[0].lago_id == '12345'


### PR DESCRIPTION
This PR adds support for shipping address that will be used in tax integrations.