### PR TITLE
feat(ProgressiveBilling): Expose Usage Threshold fields

### DIFF
--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -19,7 +19,8 @@ from .minimum_commitment import MinimumCommitment, MinimumCommitmentResponse
 from .subscription import Subscription
 from .customer_usage import Metric, ChargeObject, ChargeUsage, CustomerUsageResponse
 from .tax import Tax, Taxes, TaxResponse, TaxesResponse
-from .usage_threshold import UsageThreshold, UsageThresholds, UsageThresholdResponse, UsageThresholdsResponse
+from .usage_threshold import UsageThreshold, UsageThresholds, UsageThresholdResponse, \
+    UsageThresholdsResponse, AppliedUsageThresholdResponse, AppliedUsageThresholdsResponse
 from .wallet import Wallet, RecurringTransactionRule, RecurringTransactionRuleList, \
     RecurringTransactionRuleResponse, RecurringTransactionRuleResponseList
 from .wallet_transaction import WalletTransaction

--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -19,6 +19,7 @@ from .minimum_commitment import MinimumCommitment, MinimumCommitmentResponse
 from .subscription import Subscription
 from .customer_usage import Metric, ChargeObject, ChargeUsage, CustomerUsageResponse
 from .tax import Tax, Taxes, TaxResponse, TaxesResponse
+from .usage_threshold import UsageThreshold, UsageThresholds, UsageThresholdResponse, UsageThresholdsResponse
 from .wallet import Wallet, RecurringTransactionRule, RecurringTransactionRuleList, \
     RecurringTransactionRuleResponse, RecurringTransactionRuleResponseList
 from .wallet_transaction import WalletTransaction

--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -6,6 +6,7 @@ from .credit import CreditsResponse
 from .customer import CustomerResponse
 from .fee import FeesResponse
 from .subscription import SubscriptionsResponse
+from .usage_threshold import AppliedUsageThresholdsResponse
 from ..base_model import BaseResponseModel
 
 
@@ -96,3 +97,4 @@ class InvoiceResponse(BaseResponseModel):
     credits: Optional[CreditsResponse]
     metadata: Optional[InvoiceMetadataList]
     applied_taxes: Optional[InvoiceAppliedTaxes]
+    applied_usage_thresholds: Optional[AppliedUsageThresholdsResponse]

--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -88,6 +88,7 @@ class InvoiceResponse(BaseResponseModel):
     sub_total_including_taxes_amount_cents: int
     total_amount_cents: int
     prepaid_credit_amount_cents: int
+    progressive_billing_credit_amount_cents: int
     file_url: Optional[str]
     customer: Optional[CustomerResponse]
     subscriptions: Optional[SubscriptionsResponse]

--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -5,6 +5,7 @@ from lago_python_client.base_model import BaseModel
 from .charge import Charges, ChargesResponse, ChargesOverrides
 from .minimum_commitment import MinimumCommitment, MinimumCommitmentResponse, MinimumCommitmentOverrides
 from .tax import Taxes, TaxesResponse
+from .usage_threshold import UsageThresholds, UsageThresholdsResponse
 from ..base_model import BaseResponseModel
 
 
@@ -22,6 +23,7 @@ class Plan(BaseModel):
     charges: Optional[Charges]
     minimum_commitment: Optional[MinimumCommitment]
     tax_codes: Optional[List[str]]
+    usage_thresholds: Optional[UsageThresholds]
 
 
 class PlanResponse(BaseResponseModel):
@@ -42,6 +44,8 @@ class PlanResponse(BaseResponseModel):
     active_subscriptions_count: int
     draft_invoices_count: int
     taxes: Optional[TaxesResponse]
+    usage_thresholds: Optional[UsageThresholdsResponse]
+
 
 class PlanOverrides(BaseModel):
     name: Optional[str]
@@ -53,3 +57,4 @@ class PlanOverrides(BaseModel):
     charges: Optional[ChargesOverrides]
     minimum_commitment: Optional[MinimumCommitmentOverrides]
     tax_codes: Optional[List[str]]
+    usage_thresholds: Optional[UsageThresholds]

--- a/lago_python_client/models/usage_threshold.py
+++ b/lago_python_client/models/usage_threshold.py
@@ -1,0 +1,29 @@
+from typing import List, Optional
+
+from lago_python_client.base_model import BaseModel
+
+from ..base_model import BaseResponseModel
+
+
+class UsageThreshold(BaseModel):
+    id: Optional[str]
+    threshold_display_name: Optional[str]
+    amount_cents: int
+    recurring: bool
+
+
+class UsageThresholds(BaseModel):
+    __root__: List[UsageThreshold]
+
+
+class UsageThresholdResponse(BaseResponseModel):
+    lago_id: str
+    threshold_display_name: Optional[str]
+    amount_cents: int
+    recurring: bool
+    created_at: str
+    updated_at: str
+
+
+class UsageThresholdsResponse(BaseResponseModel):
+    __root__: List[UsageThresholdResponse]

--- a/lago_python_client/models/usage_threshold.py
+++ b/lago_python_client/models/usage_threshold.py
@@ -27,3 +27,13 @@ class UsageThresholdResponse(BaseResponseModel):
 
 class UsageThresholdsResponse(BaseResponseModel):
     __root__: List[UsageThresholdResponse]
+
+
+class AppliedUsageThresholdResponse(BaseResponseModel):
+    lifetime_usage_amount_cents: int
+    created_at: str
+    usage_threshold: UsageThresholdResponse
+
+
+class AppliedUsageThresholdsResponse(BaseResponseModel):
+    __root__: List[AppliedUsageThresholdResponse]

--- a/tests/fixtures/invoice.json
+++ b/tests/fixtures/invoice.json
@@ -19,6 +19,7 @@
     "sub_total_excluding_taxes_amount_cents": 100,
     "sub_total_including_taxes_amount_cents": 120,
     "prepaid_credit_amount_cents": 0,
+    "progressive_billing_credit_amount_cents": 0,
     "total_amount_cents": 120,
     "metadata": [
       {
@@ -112,9 +113,7 @@
           "name": "User Seats",
           "invoice_display_name": "charge_invoice_display_name",
           "filters": {
-            "region": [
-              "us-east-1"
-            ]
+            "region": ["us-east-1"]
           }
         },
         "amount_cents": 100,

--- a/tests/fixtures/invoice_index.json
+++ b/tests/fixtures/invoice_index.json
@@ -20,6 +20,7 @@
       "sub_total_excluding_taxes_amount_cents": 100,
       "sub_total_including_taxes_amount_cents": 120,
       "prepaid_credit_amount_cents": 0,
+      "progressive_billing_credit_amount_cents": 0,
       "total_amount_cents": 120,
       "applied_taxes": [
         {
@@ -56,6 +57,7 @@
       "sub_total_excluding_taxes_amount_cents": 100,
       "sub_total_including_taxes_amount_cents": 120,
       "prepaid_credit_amount_cents": 0,
+      "progressive_billing_credit_amount_cents": 0,
       "total_amount_cents": 120,
       "applied_taxes": [
         {

--- a/tests/fixtures/one_off_invoice.json
+++ b/tests/fixtures/one_off_invoice.json
@@ -19,6 +19,7 @@
     "sub_total_excluding_taxes_amount_cents": 100,
     "sub_total_including_taxes_amount_cents": 120,
     "prepaid_credit_amount_cents": 0,
+    "progressive_billing_credit_amount_cents": 0,
     "total_amount_cents": 120,
     "metadata": [
       {


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR adds:
- New `progressive_billing_credit_amount_cents` attribute to `InvoiceResponse` class
- New `UsageThreshold`, `UsageThresholdResponse` classes
- New `usage_thresholds` attribute to `Plan`, `PlanResponse` and `PlanOverrides` classes