### PR TITLE
feat(precise-amounts): Add precise amounts to fee model

### DIFF
--- a/lago_python_client/models/fee.py
+++ b/lago_python_client/models/fee.py
@@ -40,6 +40,9 @@ class FeeResponse(BaseResponseModel):
     total_amount_cents: Optional[int]
     unit_amount_cents: Optional[int]  # deprecated
     precise_unit_amount: Optional[str]
+    precise_amount: Optional[str]
+    precise_total_amount: Optional[str]
+    taxes_precise_amount: Optional[str]
     total_amount_currency: Optional[str]
     units: Optional[float]
     events_count: Optional[int]


### PR DESCRIPTION
## Context

For some customers some amounts are not enough precise as Lago convert fees to `amount_cent`.

## Description

Add precise amounts to fee model.