### PR TITLE
feat(ProgressiveBilling) - add `lifetime_usage` and `update_lifetime_usage` to Subscription

### DIFF
--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -83,3 +83,4 @@ from .usage_threshold import (
     UsageThresholdsResponse as UsageThresholdsResponse,
 )
 from .payment_request import PaymentRequest as PaymentRequest
+from .lifetime_usage import LifetimeUsageResponse as LifetimeUsageResponse

--- a/lago_python_client/models/lifetime_usage.py
+++ b/lago_python_client/models/lifetime_usage.py
@@ -1,0 +1,21 @@
+from typing import Optional, List
+
+from ..base_model import BaseResponseModel
+
+
+class LifetimeUsageThresholdResponse(BaseResponseModel):
+    amount_cents: int
+    completion_ratio: float
+    reached_at: Optional[str]
+
+
+class LifetimeUsageResponse(BaseResponseModel):
+    lago_id: str
+    lago_subscription_id: str
+    external_subscription_id: str
+    external_historical_usage_amount_cents: int
+    invoiced_usage_amount_cents: int
+    current_usage_amount_cents: int
+    from_datetime: Optional[str]
+    to_datetime: Optional[str]
+    usage_thresholds: Optional[List[LifetimeUsageThresholdResponse]]

--- a/lago_python_client/subscriptions/clients.py
+++ b/lago_python_client/subscriptions/clients.py
@@ -8,7 +8,20 @@ from ..mixins import (
     FindCommandMixin,
     UpdateCommandMixin,
 )
+from ..models.lifetime_usage import LifetimeUsageResponse
 from ..models.subscription import SubscriptionResponse
+from ..services.request import (
+    make_headers,
+    make_url,
+    send_get_request,
+    send_put_request,
+)
+from ..services.response import (
+    Response,
+    get_response_data,
+    prepare_object_response,
+)
+from ..services.json import to_json
 
 
 class SubscriptionClient(
@@ -22,3 +35,36 @@ class SubscriptionClient(
     API_RESOURCE: ClassVar[str] = "subscriptions"
     RESPONSE_MODEL: ClassVar[Type[SubscriptionResponse]] = SubscriptionResponse
     ROOT_NAME: ClassVar[str] = "subscription"
+
+    def lifetime_usage(self, resource_id: str) -> LifetimeUsageResponse:
+        api_response: Response = send_get_request(
+            url=make_url(
+                origin=self.base_url,
+                path_parts=(self.API_RESOURCE, resource_id, "lifetime_usage"),
+            ),
+            headers=make_headers(api_key=self.api_key),
+        )
+
+        return prepare_object_response(
+            response_model=LifetimeUsageResponse,
+            data=get_response_data(response=api_response, key="lifetime_usage"),
+        )
+
+    def update_lifetime_usage(
+        self, resource_id: str, external_historical_usage_amount_cents: int
+    ) -> LifetimeUsageResponse:
+        api_response: Response = send_put_request(
+            url=make_url(
+                origin=self.base_url,
+                path_parts=(self.API_RESOURCE, resource_id, "lifetime_usage"),
+            ),
+            content=to_json(
+                {"lifetime_usage": {"external_historical_usage_amount_cents": external_historical_usage_amount_cents}}
+            ),
+            headers=make_headers(api_key=self.api_key),
+        )
+
+        return prepare_object_response(
+            response_model=LifetimeUsageResponse,
+            data=get_response_data(response=api_response, key="lifetime_usage"),
+        )

--- a/tests/fixtures/lifetime_usage.json
+++ b/tests/fixtures/lifetime_usage.json
@@ -1,0 +1,24 @@
+{
+  "lifetime_usage": {
+    "lago_id": "ef555447-b017-4345-9846-6b814cfb4148",
+    "lago_subscription_id": "d644084c-0673-4573-8104-6093bf143acb",
+    "external_subscription_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "external_historical_usage_amount_cents": 0,
+    "invoiced_usage_amount_cents": 0,
+    "current_usage_amount_cents": 3000,
+    "from_datetime": "2024-09-04T00:00:00Z",
+    "to_datetime": "2024-09-05T12:49:28Z",
+    "usage_thresholds": [
+      {
+        "amount_cents": 2000,
+        "completion_ratio": 1,
+        "reached_at": "2024-09-05T12:49:25.604Z"
+      },
+      {
+        "amount_cents": 4000,
+        "completion_ratio": 0.5,
+        "reached_at": null
+      }
+    ]
+  }
+}

--- a/tests/fixtures/update_lifetime_usage.json
+++ b/tests/fixtures/update_lifetime_usage.json
@@ -1,0 +1,24 @@
+{
+  "lifetime_usage": {
+    "lago_id": "ef555447-b017-4345-9846-6b814cfb4148",
+    "lago_subscription_id": "d644084c-0673-4573-8104-6093bf143acb",
+    "external_subscription_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "external_historical_usage_amount_cents": 2000,
+    "invoiced_usage_amount_cents": 0,
+    "current_usage_amount_cents": 3000,
+    "from_datetime": "2024-09-04T00:00:00Z",
+    "to_datetime": "2024-09-05T12:49:28Z",
+    "usage_thresholds": [
+      {
+        "amount_cents": 2000,
+        "completion_ratio": 1,
+        "reached_at": "2024-09-05T12:49:25.604Z"
+      },
+      {
+        "amount_cents": 4000,
+        "completion_ratio": 0.5,
+        "reached_at": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

Adds 2 methods `lifetime_usage` and `update_lifetime_usage` to Subscription client. 