### PR TITLE
fix: Improve LagoApiError details

### DIFF
--- a/lago_python_client/exceptions.py
+++ b/lago_python_client/exceptions.py
@@ -24,7 +24,8 @@ class LagoApiError(Exception):
         self.response = response
         self.detail = detail
         self.headers = headers
+        super().__init__(self.response)
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-        return f"{class_name}(status_code={self.status_code!r}, detail={self.detail!r})"
+        return f"{class_name}(response={self.response!r}"

--- a/tests/fixtures/event_unprocessable_entity.json
+++ b/tests/fixtures/event_unprocessable_entity.json
@@ -1,0 +1,6 @@
+{
+  "status": 422,
+  "error": "Unprocessable Entity",
+  "code": "validation_errors",
+  "error_details": { "transaction_id": ["value_already_exist"] }
+}

--- a/tests/test_event_client.py
+++ b/tests/test_event_client.py
@@ -45,6 +45,14 @@ def mock_response():
         return event_response.read()
 
 
+def mock_unprocessable_entity_response():
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    data_path = os.path.join(this_dir, "fixtures/event_unprocessable_entity.json")
+
+    with open(data_path, "rb") as unprocessable_entity_response:
+        return unprocessable_entity_response.read()
+
+
 def mock_fees_response():
     this_dir = os.path.dirname(os.path.abspath(__file__))
     data_path = os.path.join(this_dir, "fixtures/fees.json")
@@ -68,13 +76,13 @@ def test_valid_create_events_request_with_string_timestamp(httpx_mock: HTTPXMock
 
 
 def test_invalid_create_events_request(httpx_mock: HTTPXMock):
-    client = Client(api_key="invalid")
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
 
     httpx_mock.add_response(
         method="POST",
         url="https://api.getlago.com/api/v1/events",
-        status_code=401,
-        content=b"",
+        status_code=422,
+        content=mock_unprocessable_entity_response(),
     )
 
     with pytest.raises(LagoApiError):


### PR DESCRIPTION
This PR fixes https://github.com/getlago/lago-python-client/issues/266

It makes sure that `LagoApiError` shows a comprehensible message in the output. It will render the API response, allowing user to quickly understand the source of the error.

### Before
```
lago_python_client.exceptions.LagoApiError
```

### After
```
lago_python_client.exceptions.LagoApiError: {'status': 422, 'error': 'Unprocessable Entity', 'code': 'validation_errors', 'error_details': {'transaction_id': ['value_already_exist']}}
```