### PR TITLE
feat(DynamicPricing): Expose Event#precise_total_amount_cents

### DIFF
--- a/lago_python_client/models/event.py
+++ b/lago_python_client/models/event.py
@@ -10,6 +10,7 @@ class Event(BaseModel):
     external_subscription_id: str
     code: str
     timestamp: Optional[Union[int, str]]
+    precise_total_amount_cents: Optional[str]
     properties: Optional[Dict[str, Any]]
 
 
@@ -25,6 +26,7 @@ class EventResponse(BaseResponseModel):
     external_subscription_id: str
     code: str
     timestamp: str
+    precise_total_amount_cents: Optional[str]
     properties: Optional[Dict[str, Any]]
     created_at: str
 

--- a/tests/fixtures/event.json
+++ b/tests/fixtures/event.json
@@ -5,6 +5,7 @@
     "external_subscription_id": "24691b9a-7330-409d-9dfd-d80582593297",
     "code": "test",
     "timestamp": "2022-04-29T08:59:51Z",
+    "precise_total_amount_cents": "123.45",
     "properties": {
       "custom_field": "custom"
     },


### PR DESCRIPTION
## Context

AI, CPaaS and Fintech customers can apply a price to a unit that fluctuates over time. Currently Lago does not support this usecase.

## Description

This PR is related to https://github.com/getlago/lago-api/pull/2610.
It documents the new `precise_total_amount_cents` in input and result payloads on `POST /api/v1/events` and `POST /api/v1/batch_events`