### PR TITLE
misc: Remove *_count fields

### DIFF
--- a/lago_python_client/models/billable_metric.py
+++ b/lago_python_client/models/billable_metric.py
@@ -42,9 +42,6 @@ class BillableMetricResponse(BaseResponseModel):
     field_name: Optional[str]
     created_at: str
     filters: BillableMetricFilters
-    active_subscriptions_count: int
-    draft_invoices_count: int
-    plans_count: int
 
 
 class BillableMetricEvaluateExpressionEvent(BaseModel):

--- a/lago_python_client/models/plan.py
+++ b/lago_python_client/models/plan.py
@@ -51,8 +51,6 @@ class PlanResponse(BaseResponseModel):
     charges: Optional[ChargesResponse]
     minimum_commitment: Optional[MinimumCommitmentResponse]
     usage_thresholds: Optional[UsageThresholdsResponse]
-    active_subscriptions_count: Optional[int]
-    draft_invoices_count: Optional[int]
     taxes: Optional[TaxesResponse]
 
 

--- a/lago_python_client/models/tax.py
+++ b/lago_python_client/models/tax.py
@@ -23,10 +23,6 @@ class TaxResponse(BaseResponseModel):
     code: str
     rate: float
     description: Optional[str]
-    add_ons_count: Optional[int]
-    customers_count: Optional[int]
-    plans_count: Optional[int]
-    charges_count: Optional[int]
     applied_to_organization: bool
     created_at: str
 

--- a/tests/fixtures/billable_metric.json
+++ b/tests/fixtures/billable_metric.json
@@ -17,9 +17,6 @@
         "key": "country",
         "values": ["france", "italy", "spain"]
       }
-    ],
-    "active_subscriptions_count": 0,
-    "draft_invoices_count": 0,
-    "plans_count": 0
+    ]
   }
 }

--- a/tests/fixtures/billable_metric_index.json
+++ b/tests/fixtures/billable_metric_index.json
@@ -13,10 +13,7 @@
       "expression": "1 + 2",
       "field_name": "amount_sum",
       "created_at": "2022-04-29T08:59:51Z",
-      "filters": [],
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
-      "plans_count": 0
+      "filters": []
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314a11111",
@@ -31,10 +28,7 @@
       "expression": "1 + 2",
       "field_name": "amount_sum",
       "created_at": "2022-04-30T08:59:51Z",
-      "filters": [],
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
-      "plans_count": 0
+      "filters": []
     }
   ],
   "meta": {

--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -12,8 +12,6 @@
     "trial_period": 3.0,
     "pay_in_advance": true,
     "bill_charges_monthly": null,
-    "active_subscriptions_count": 0,
-    "draft_invoices_count": 0,
     "charges": [
       {
         "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
@@ -49,10 +47,6 @@
             "code": "tax_code",
             "rate": 15.0,
             "description": "tax_desc",
-            "add_ons_count": 0,
-            "customers_count": 0,
-            "plans_count": 0,
-            "charges_count": 0,
             "applied_to_organization": false,
             "created_at": "2022-04-29T08:59:51Z"
           }
@@ -80,10 +74,6 @@
         "code": "tax_code",
         "rate": 15.0,
         "description": "tax_desc",
-        "add_ons_count": 0,
-        "customers_count": 0,
-        "plans_count": 0,
-        "charges_count": 0,
         "applied_to_organization": false,
         "created_at": "2022-04-29T08:59:51Z"
       }

--- a/tests/fixtures/plan_index.json
+++ b/tests/fixtures/plan_index.json
@@ -13,8 +13,6 @@
       "trial_period": 3.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
       "charges": [
         {
           "lago_id": "51c1e851-5be6-4343-a0ee-39a81d8b4ee1",
@@ -32,11 +30,7 @@
                 "amount": "0.22"
               },
               "values": {
-                "country": [
-                  "france",
-                  "italy",
-                  "spain"
-                ]
+                "country": ["france", "italy", "spain"]
               },
               "invoice_display_name": "Europe"
             }
@@ -62,8 +56,6 @@
       "trial_period": 2.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
       "charges": [
         {
           "lago_id": "dfdc725d-6341-4d61-831e-4ac9ccd509c0",
@@ -93,8 +85,6 @@
       "trial_period": 0.0,
       "pay_in_advance": true,
       "bill_charges_monthly": null,
-      "active_subscriptions_count": 0,
-      "draft_invoices_count": 0,
       "charges": []
     }
   ],

--- a/tests/fixtures/tax.json
+++ b/tests/fixtures/tax.json
@@ -5,10 +5,6 @@
     "code": "tax_code",
     "rate": 15.0,
     "description": "tax_desc",
-    "add_ons_count": 0,
-    "customers_count": 0,
-    "plans_count": 0,
-    "charges_count": 0,
     "applied_to_organization": false,
     "created_at": "2022-04-29T08:59:51Z"
   }

--- a/tests/fixtures/tax_index.json
+++ b/tests/fixtures/tax_index.json
@@ -5,9 +5,6 @@
       "name": "tax_name_1",
       "code": "tax_code_1",
       "rate": 15.0,
-      "add_ons_count": 0,
-      "customers_count": 0,
-      "plans_count": 0,
       "description": "tax_desc_1",
       "applied_to_organization": false,
       "created_at": "2022-04-29T08:59:51Z"
@@ -17,10 +14,6 @@
       "name": "tax_name_2",
       "code": "tax_code_2",
       "rate": 20.0,
-      "add_ons_count": 0,
-      "customers_count": 0,
-      "plans_count": 0,
-      "charges_count": 0,
       "description": "tax_desc_2",
       "applied_to_organization": false,
       "created_at": "2022-04-29T08:59:51Z"


### PR DESCRIPTION
# Context

The API response are returning a lot of counters. Since the exposed resources can be linked to a lot of objects and can be called a lot, these counters are posing a scalability problem and are slowing down the global performance of the API.

To remediate the situation the decision was made to remove all these fields.

# Changes

This PR removes the following fields:
- BillableMetric
  -  active_subscriptions_count
  - draft_invoices_count
  - plans_count
- Plan
  - active_subscriptions_count
  - draft_invoices_count
- Tax
  - add_ons_count
  - charges_count
  - customers_count
  - plans_count