### PR TITLE
feat: add apply taxes params to current usage

### DIFF
--- a/lago_python_client/customers/clients.py
+++ b/lago_python_client/customers/clients.py
@@ -35,13 +35,14 @@ class CustomerClient(
     RESPONSE_MODEL: ClassVar[Type[CustomerResponse]] = CustomerResponse
     ROOT_NAME: ClassVar[str] = "customer"
 
-    def current_usage(self, resource_id: str, external_subscription_id: str) -> CustomerUsageResponse:
+    def current_usage(self, resource_id: str, external_subscription_id: str, apply_taxes: bool = True) -> CustomerUsageResponse:
         api_response: Response = send_get_request(
             url=make_url(
                 origin=self.base_url,
                 path_parts=(self.API_RESOURCE, resource_id, "current_usage"),
                 query_pairs={
                     "external_subscription_id": external_subscription_id,
+                    "apply_taxes": str(apply_taxes).lower(),
                 },
             ),
             headers=make_headers(api_key=self.api_key),

--- a/lago_python_client/customers/clients.py
+++ b/lago_python_client/customers/clients.py
@@ -35,7 +35,9 @@ class CustomerClient(
     RESPONSE_MODEL: ClassVar[Type[CustomerResponse]] = CustomerResponse
     ROOT_NAME: ClassVar[str] = "customer"
 
-    def current_usage(self, resource_id: str, external_subscription_id: str, apply_taxes: bool = True) -> CustomerUsageResponse:
+    def current_usage(
+        self, resource_id: str, external_subscription_id: str, apply_taxes: bool = True
+    ) -> CustomerUsageResponse:
         api_response: Response = send_get_request(
             url=make_url(
                 origin=self.base_url,

--- a/lago_python_client/customers/clients.py
+++ b/lago_python_client/customers/clients.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, Mapping, ClassVar, Type
+from typing import Any, Mapping, ClassVar, Type, Optional
 
 from ..base_client import BaseClient
 from ..mixins import (
@@ -36,16 +36,17 @@ class CustomerClient(
     ROOT_NAME: ClassVar[str] = "customer"
 
     def current_usage(
-        self, resource_id: str, external_subscription_id: str, apply_taxes: bool = True
+        self, resource_id: str, external_subscription_id: str, apply_taxes: Optional[str] = None
     ) -> CustomerUsageResponse:
+        query_params = {"external_subscription_id": external_subscription_id}
+        if apply_taxes is not None:
+            query_params["apply_taxes"] = apply_taxes
+
         api_response: Response = send_get_request(
             url=make_url(
                 origin=self.base_url,
                 path_parts=(self.API_RESOURCE, resource_id, "current_usage"),
-                query_pairs={
-                    "external_subscription_id": external_subscription_id,
-                    "apply_taxes": str(apply_taxes).lower(),
-                },
+                query_pairs=query_params,
             ),
             headers=make_headers(api_key=self.api_key),
         )

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -128,6 +128,7 @@ def test_valid_current_usage(httpx_mock: HTTPXMock):
     assert len(response.charges_usage[0].filters) == 1
     assert response.charges_usage[0].filters[0].values["country"] == ["france"]
 
+
 def test_valid_current_usage_without_taxes(httpx_mock: HTTPXMock):
     client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
 

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -117,7 +117,7 @@ def test_valid_current_usage(httpx_mock: HTTPXMock):
 
     httpx_mock.add_response(
         method="GET",
-        url="https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123&apply_taxes=true",
+        url="https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123",
         content=mock_response("customer_usage"),
     )
     response = client.customers.current_usage("external_customer_id", "123")
@@ -137,7 +137,7 @@ def test_valid_current_usage_without_taxes(httpx_mock: HTTPXMock):
         url="https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123&apply_taxes=false",
         content=mock_response("customer_usage"),
     )
-    response = client.customers.current_usage("external_customer_id", "123", False)
+    response = client.customers.current_usage("external_customer_id", "123", "false")
 
     assert response.from_datetime == "2022-07-01T00:00:00Z"
     assert len(response.charges_usage) == 1
@@ -151,7 +151,7 @@ def test_invalid_current_usage(httpx_mock: HTTPXMock):
 
     httpx_mock.add_response(
         method="GET",
-        url="https://api.getlago.com/api/v1/customers/invalid_customer/current_usage?external_subscription_id=123&apply_taxes=true",
+        url="https://api.getlago.com/api/v1/customers/invalid_customer/current_usage?external_subscription_id=123",
         status_code=404,
         content=b"",
     )

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -117,10 +117,26 @@ def test_valid_current_usage(httpx_mock: HTTPXMock):
 
     httpx_mock.add_response(
         method="GET",
-        url="https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123",
+        url="https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123&apply_taxes=true",
         content=mock_response("customer_usage"),
     )
     response = client.customers.current_usage("external_customer_id", "123")
+
+    assert response.from_datetime == "2022-07-01T00:00:00Z"
+    assert len(response.charges_usage) == 1
+    assert response.charges_usage[0].units == 1.0
+    assert len(response.charges_usage[0].filters) == 1
+    assert response.charges_usage[0].filters[0].values["country"] == ["france"]
+
+def test_valid_current_usage_without_taxes(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.getlago.com/api/v1/customers/external_customer_id/current_usage?external_subscription_id=123&apply_taxes=false",
+        content=mock_response("customer_usage"),
+    )
+    response = client.customers.current_usage("external_customer_id", "123", False)
 
     assert response.from_datetime == "2022-07-01T00:00:00Z"
     assert len(response.charges_usage) == 1
@@ -134,7 +150,7 @@ def test_invalid_current_usage(httpx_mock: HTTPXMock):
 
     httpx_mock.add_response(
         method="GET",
-        url="https://api.getlago.com/api/v1/customers/invalid_customer/current_usage?external_subscription_id=123",
+        url="https://api.getlago.com/api/v1/customers/invalid_customer/current_usage?external_subscription_id=123&apply_taxes=true",
         status_code=404,
         content=b"",
     )


### PR DESCRIPTION
Updated the current_usage method to accept an optional apply_taxes parameter, defaulting to True. This parameter is included in the query string as a lowercase string ("true" or "false").