### PR TITLE
feat(pricing_group_keys): Update fixtures for tests

### DIFF
--- a/tests/fixtures/plan.json
+++ b/tests/fixtures/plan.json
@@ -27,7 +27,7 @@
         "min_amount_cents": 0,
         "properties": {
           "amount": "0.22",
-          "grouped_by": ["agent_name"]
+          "pricing_group_keys": ["agent_name"]
         },
         "filters": [
           {


### PR DESCRIPTION
## Context

This PR is related to https://github.com/getlago/lago-api/pull/3790

## Description

It updates the `plan` and `plans` fixtures to replace the deprecated `group_by` field the new `pricing_group_keys`