### PR TITLE
feat(wallet-limitations): add support for wallet fee type limitation

### DIFF
--- a/lago_python_client/models/__init__.py
+++ b/lago_python_client/models/__init__.py
@@ -88,6 +88,7 @@ from .wallet import (
     RecurringTransactionRuleList as RecurringTransactionRuleList,
     RecurringTransactionRuleResponse as RecurringTransactionRuleResponse,
     RecurringTransactionRuleResponseList as RecurringTransactionRuleResponseList,
+    AppliesTo as AppliesTo,
 )
 from .wallet_transaction import WalletTransaction as WalletTransaction
 from .webhook_endpoint import WebhookEndpoint as WebhookEndpoint

--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -43,6 +43,10 @@ class RecurringTransactionRuleResponseList(BaseModel):
     __root__: List[RecurringTransactionRuleResponse]
 
 
+class AppliesTo(BaseModel):
+    fee_types: Optional[List[str]]
+
+
 class Wallet(BaseModel):
     external_customer_id: Optional[str]
     rate_amount: Optional[str]
@@ -53,6 +57,7 @@ class Wallet(BaseModel):
     currency: Optional[str]
     recurring_transaction_rules: Optional[RecurringTransactionRuleList]
     transaction_metadata: Optional[List[Dict[str, str]]]
+    applies_to: Optional[AppliesTo]
 
 
 class WalletResponse(BaseResponseModel):
@@ -76,3 +81,4 @@ class WalletResponse(BaseResponseModel):
     ongoing_usage_balance_cents: int
     credits_ongoing_balance: str
     credits_ongoing_usage_balance: str
+    applies_to: Optional[AppliesTo]

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -29,6 +29,9 @@
     "ongoing_balance_cents": 800,
     "ongoing_usage_balance_cents": 200,
     "credits_ongoing_balance": "8.0",
-    "credits_ongoing_usage_balance": "2.0"
+    "credits_ongoing_usage_balance": "2.0",
+    "applies_to": {
+      "fee_types": ["charge"]
+    }
   }
 }

--- a/tests/fixtures/wallet_index.json
+++ b/tests/fixtures/wallet_index.json
@@ -30,7 +30,10 @@
           "started_at": null,
           "target_ongoing_balance": null
         }
-      ]
+      ],
+      "applies_to": {
+        "fee_types": ["charge"]
+      }
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac1111",
@@ -51,7 +54,10 @@
       "ongoing_usage_balance_cents": 200,
       "credits_ongoing_balance": "8.0",
       "credits_ongoing_usage_balance": "2.0",
-      "recurring_transaction_rules": []
+      "recurring_transaction_rules": [],
+      "applies_to": {
+        "fee_types": ["charge"]
+      }
     }
   ],
   "meta": {

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -9,6 +9,7 @@ from lago_python_client.models import (
     Wallet,
     RecurringTransactionRule,
     RecurringTransactionRuleList,
+    AppliesTo,
 )
 
 
@@ -22,6 +23,7 @@ def wallet_object():
         target_ongoing_balance="105.0",
     )
     rules_list = RecurringTransactionRuleList(__root__=[rule])
+    applies_to = AppliesTo(fee_types=["charge"])
     return Wallet(
         name="name",
         external_customer_id="12345",
@@ -29,6 +31,7 @@ def wallet_object():
         paid_credits="10",
         granted_credits="10",
         recurring_transaction_rules=rules_list,
+        applies_to=applies_to,
     )
 
 
@@ -62,6 +65,7 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
     assert response.recurring_transaction_rules.__root__[0].lago_id == "12345"
     assert response.recurring_transaction_rules.__root__[0].trigger == "interval"
     assert response.recurring_transaction_rules.__root__[0].interval == "monthly"
+    assert response.applies_to.fee_types[0] == "charge"
 
 
 def test_invalid_create_wallet_request(httpx_mock: HTTPXMock):


### PR DESCRIPTION
This PR adds support for applies_to attribute that handles wallet limitations