### PR TITLE
feat(subscription): Add `on_termination_credit_note` field to subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This is a python wrapper for Lago API
 
 ## Current Releases
 
-| Project            | Release Badge                                                                                       |
-|--------------------|-----------------------------------------------------------------------------------------------------|
-| **Lago**           | [![Lago Release](https://img.shields.io/github/v/release/getlago/lago)](https://github.com/getlago/lago/releases) |
-| **Lago Python Client**     | [![Lago Python Client Release](https://img.shields.io/github/v/release/getlago/lago-python-client)](https://github.com/getlago/lago-python-client/releases) |
+| Project                | Release Badge                                                                                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Lago**               | [![Lago Release](https://img.shields.io/github/v/release/getlago/lago)](https://github.com/getlago/lago/releases)                                           |
+| **Lago Python Client** | [![Lago Python Client Release](https://img.shields.io/github/v/release/getlago/lago-python-client)](https://github.com/getlago/lago-python-client/releases) |
 
 ## Installation
 
@@ -32,13 +32,19 @@ Check the [lago API reference](https://doc.getlago.com/docs/api/intro)
 
 ```bash
 python -m pip install --upgrade pip setuptools wheel
-python -m pip install '.[test]'
+python -m pip install '.[test,lint]'
 ```
 
 ### Run tests
 
 ```bash
 pytest
+```
+
+### Lint
+
+```bash
+ruff format
 ```
 
 ## Documentation

--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -44,6 +44,7 @@ class SubscriptionResponse(BaseResponseModel):
     downgrade_plan_date: Optional[str]
     current_billing_period_started_at: Optional[str]
     current_billing_period_ending_at: Optional[str]
+    on_termination_credit_note: Optional[str]
 
 
 class SubscriptionsResponse(BaseResponseModel):

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,5 +39,8 @@ test =
     pytest
     pytest_httpx
 
+lint =
+    ruff
+
 [options.package_data]
 * = py.typed

--- a/tests/fixtures/subscription.json
+++ b/tests/fixtures/subscription.json
@@ -11,6 +11,7 @@
     "status": "active",
     "billing_time": "anniversary",
     "terminated_at": null,
+    "on_termination_credit_note": "skip",
     "subscription_at": "2022-04-29T08:59:51Z",
     "previous_plan_code": null,
     "next_plan_code": null,

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -140,6 +140,22 @@ def test_valid_destroy_subscription_request(httpx_mock: HTTPXMock):
     assert response.plan_code == "eartha lynch"
 
 
+def test_valid_destroy_subscription_with_on_termination_credit_note_request(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+    identifier = "sub_id"
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url="https://api.getlago.com/api/v1/subscriptions/" + identifier + "?on_termination_credit_note=skip",
+        content=mock_response(),
+    )
+    response = client.subscriptions.destroy(identifier, {"on_termination_credit_note": "skip"})
+
+    assert response.external_customer_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
+    assert response.status == "active"
+    assert response.plan_code == "eartha lynch"
+
+
 def test_valid_destroy_pending_subscription_request(httpx_mock: HTTPXMock):
     client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
     identifier = "sub_id"

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -154,6 +154,7 @@ def test_valid_destroy_subscription_with_on_termination_credit_note_request(http
     assert response.external_customer_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.status == "active"
     assert response.plan_code == "eartha lynch"
+    assert response.on_termination_credit_note == "skip"
 
 
 def test_valid_destroy_pending_subscription_request(httpx_mock: HTTPXMock):


### PR DESCRIPTION
This also updates the `setup.cfg` to include `ruff` as a dependency and add a "Linting" section in the README.