### PR TITLE
feat (wallets): add support for wallet bm limitation

### DIFF
--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -45,6 +45,7 @@ class RecurringTransactionRuleResponseList(BaseModel):
 
 class AppliesTo(BaseModel):
     fee_types: Optional[List[str]]
+    billable_metric_codes: Optional[List[str]]
 
 
 class Wallet(BaseModel):

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -31,7 +31,8 @@
     "credits_ongoing_balance": "8.0",
     "credits_ongoing_usage_balance": "2.0",
     "applies_to": {
-      "fee_types": ["charge"]
+      "fee_types": ["charge"],
+      "billable_metric_codes": ["usage"]
     }
   }
 }

--- a/tests/fixtures/wallet_index.json
+++ b/tests/fixtures/wallet_index.json
@@ -32,7 +32,8 @@
         }
       ],
       "applies_to": {
-        "fee_types": ["charge"]
+        "fee_types": ["charge"],
+        "billable_metric_codes": ["usage"]
       }
     },
     {
@@ -56,7 +57,8 @@
       "credits_ongoing_usage_balance": "2.0",
       "recurring_transaction_rules": [],
       "applies_to": {
-        "fee_types": ["charge"]
+        "fee_types": ["charge"],
+        "billable_metric_codes": ["usage"]
       }
     }
   ],

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -23,7 +23,10 @@ def wallet_object():
         target_ongoing_balance="105.0",
     )
     rules_list = RecurringTransactionRuleList(__root__=[rule])
-    applies_to = AppliesTo(fee_types=["charge"])
+    applies_to = AppliesTo(
+        fee_types=["charge"],
+        billable_metric_codes=["usage"],
+    )
     return Wallet(
         name="name",
         external_customer_id="12345",
@@ -66,6 +69,7 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
     assert response.recurring_transaction_rules.__root__[0].trigger == "interval"
     assert response.recurring_transaction_rules.__root__[0].interval == "monthly"
     assert response.applies_to.fee_types[0] == "charge"
+    assert response.applies_to.billable_metric_codes[0] == "usage"
 
 
 def test_invalid_create_wallet_request(httpx_mock: HTTPXMock):


### PR DESCRIPTION
This PR adds support for limiting wallet consumption on specific billable metric types.

New attribute called `billable_metric_codes` is added inside `applies_to` object in both request and response.