### PR TITLE
feat(subscription): Allow to skip invoice on subscription termination

### DIFF
--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -45,6 +45,7 @@ class SubscriptionResponse(BaseResponseModel):
     current_billing_period_started_at: Optional[str]
     current_billing_period_ending_at: Optional[str]
     on_termination_credit_note: Optional[str]
+    on_termination_invoice: Optional[str]
 
 
 class SubscriptionsResponse(BaseResponseModel):

--- a/tests/fixtures/subscription.json
+++ b/tests/fixtures/subscription.json
@@ -12,6 +12,7 @@
     "billing_time": "anniversary",
     "terminated_at": null,
     "on_termination_credit_note": "skip",
+    "on_termination_invoice": "skip",
     "subscription_at": "2022-04-29T08:59:51Z",
     "previous_plan_code": null,
     "next_plan_code": null,

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -140,21 +140,26 @@ def test_valid_destroy_subscription_request(httpx_mock: HTTPXMock):
     assert response.plan_code == "eartha lynch"
 
 
-def test_valid_destroy_subscription_with_on_termination_credit_note_request(httpx_mock: HTTPXMock):
+def test_valid_destroy_subscription_with_on_termination_actions_request(httpx_mock: HTTPXMock):
     client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
     identifier = "sub_id"
 
     httpx_mock.add_response(
         method="DELETE",
-        url="https://api.getlago.com/api/v1/subscriptions/" + identifier + "?on_termination_credit_note=skip",
+        url="https://api.getlago.com/api/v1/subscriptions/"
+        + identifier
+        + "?on_termination_credit_note=skip&on_termination_invoice=skip",
         content=mock_response(),
     )
-    response = client.subscriptions.destroy(identifier, {"on_termination_credit_note": "skip"})
+    response = client.subscriptions.destroy(
+        identifier, {"on_termination_credit_note": "skip", "on_termination_invoice": "skip"}
+    )
 
     assert response.external_customer_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.status == "active"
     assert response.plan_code == "eartha lynch"
     assert response.on_termination_credit_note == "skip"
+    assert response.on_termination_invoice == "skip"
 
 
 def test_valid_destroy_pending_subscription_request(httpx_mock: HTTPXMock):


### PR DESCRIPTION
This is related to https://github.com/getlago/lago-api/pull/4047.