### PR TITLE
dependency: Update`typeguard` to version 4

### DIFF
--- a/lago_python_client/webhooks/clients.py
+++ b/lago_python_client/webhooks/clients.py
@@ -9,7 +9,7 @@ except ImportError:
     from typing_extensions import TypedDict
 
 from lago_python_client.base_model import BaseModel
-import typeguard
+from typeguard import check_type, CollectionCheckStrategy, TypeCheckError
 
 from ..base_client import BaseClient
 from ..exceptions import LagoApiError
@@ -20,8 +20,6 @@ if sys.version_info >= (3, 9):
     from collections.abc import Mapping, Sequence
 else:
     from typing import Mapping, Sequence
-
-typeguard.config.collection_check_strategy = typeguard.CollectionCheckStrategy.ALL_ITEMS
 
 
 class _ResponseWithPublicKeyInside(TypedDict):
@@ -46,10 +44,10 @@ class WebhookClient(BaseClient):
         )
 
         try:
-            checked_response_data: _ResponseWithPublicKeyInside = typeguard.check_type(
-                response_data, _ResponseWithPublicKeyInside
+            checked_response_data: _ResponseWithPublicKeyInside = check_type(
+                response_data, _ResponseWithPublicKeyInside, collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS
             )  # type: ignore
-        except typeguard.TypeCheckError:
+        except TypeCheckError:
             raise LagoApiError(
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,  # 500
                 url=None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     httpx>=0.24.0,<1.0.0 # minor auto updates allowed
     orjson~=3.8  # minor auto updates allowed
     pydantic>=1.10,<3 # minor auto updates allowed
-    typeguard~=3.0.2  # bugfix auto updates allowed
+    typeguard~=4.0  # bugfix auto updates allowed
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This upgrade includes a breaking change in the `typeguard` API. `typeguard.check_type` doesn't rely on `typeguard.config` anymore. The solutions are either:

- Explicitely mention the config in the `typeguard.check_type`
- Rely on the `@typechecked` decorator

I went for the first one as we don't have many call to `typeguard.check_type`.

Note that version 4.0.0 was released on 2023-05-12 so there's no reason to try and maintain compatibility with versions < 4.