### PR TITLE
feat(wallet-transaction): Add `transaction_name` to wallet transaction rules

### DIFF
--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -36,6 +36,7 @@ class RecurringTransactionRuleResponse(BaseModel):
     transaction_metadata: Optional[List[Dict[str, str]]]
     transaction_name: Optional[str]
 
+
 class RecurringTransactionRuleList(BaseModel):
     __root__: List[RecurringTransactionRule]
 

--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -17,6 +17,7 @@ class RecurringTransactionRule(BaseModel):
     expiration_at: Optional[str]
     target_ongoing_balance: Optional[str]
     transaction_metadata: Optional[List[Dict[str, str]]]
+    transaction_name: Optional[str]
 
 
 class RecurringTransactionRuleResponse(BaseModel):
@@ -33,7 +34,7 @@ class RecurringTransactionRuleResponse(BaseModel):
     target_ongoing_balance: Optional[str]
     created_at: Optional[str]
     transaction_metadata: Optional[List[Dict[str, str]]]
-
+    transaction_name: Optional[str]
 
 class RecurringTransactionRuleList(BaseModel):
     __root__: List[RecurringTransactionRule]

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -23,7 +23,8 @@
         "paid_credits": "105.0",
         "granted_credits": "105.0",
         "started_at": null,
-        "target_ongoing_balance": "200.0"
+        "target_ongoing_balance": "200.0",
+        "transaction_name": "Recurring Transaction Rule"
       }
     ],
     "ongoing_balance_cents": 800,

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -21,6 +21,7 @@ def wallet_object():
         granted_credits="105.0",
         method="target",
         target_ongoing_balance="105.0",
+        transaction_name="Recurring Transaction Rule",
     )
     rules_list = RecurringTransactionRuleList(__root__=[rule])
     applies_to = AppliesTo(


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-the-name-of-a-wallet-transaction-at-top-up

## Context

Follow up of https://github.com/getlago/lago-api/pull/4282.

## Description

This adds a `transaction_name` to the wallet transaction recurring rule types that are then used to populate the name of the triggered wallet transactions.

