### PR TITLE
fix(wallet): Add `invoice_requires_successful_payment` field to Wallet and WalletTransaction models

### DIFF
--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -59,6 +59,7 @@ class Wallet(BaseModel):
     recurring_transaction_rules: Optional[RecurringTransactionRuleList]
     transaction_metadata: Optional[List[Dict[str, str]]]
     applies_to: Optional[AppliesTo]
+    invoice_requires_successful_payment: Optional[bool]
 
 
 class WalletResponse(BaseResponseModel):
@@ -83,3 +84,4 @@ class WalletResponse(BaseResponseModel):
     credits_ongoing_balance: str
     credits_ongoing_usage_balance: str
     applies_to: Optional[AppliesTo]
+    invoice_requires_successful_payment: Optional[bool]

--- a/lago_python_client/models/wallet_transaction.py
+++ b/lago_python_client/models/wallet_transaction.py
@@ -10,6 +10,7 @@ class WalletTransaction(BaseModel):
     paid_credits: Optional[str]
     granted_credits: Optional[str]
     voided_credits: Optional[str]
+    invoice_requires_successful_payment: Optional[bool]
     metadata: Optional[List[Dict[str, str]]]
     name: Optional[str]
 
@@ -28,3 +29,4 @@ class WalletTransactionResponse(BaseResponseModel):
     created_at: str
     metadata: Optional[List[Dict[str, str]]]
     name: Optional[str]
+    invoice_requires_successful_payment: Optional[bool]

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -35,6 +35,7 @@ def wallet_object():
         granted_credits="10",
         recurring_transaction_rules=rules_list,
         applies_to=applies_to,
+        invoice_requires_successful_payment=False,
     )
 
 

--- a/tests/test_wallet_transaction_client.py
+++ b/tests/test_wallet_transaction_client.py
@@ -10,7 +10,12 @@ from lago_python_client.models import WalletTransaction
 
 def wallet_transaction_object():
     return WalletTransaction(
-        wallet_id="123", paid_credits="10", granted_credits="10", voided_credits="0", name="Transaction Name"
+        wallet_id="123",
+        paid_credits="10",
+        granted_credits="10",
+        voided_credits="0",
+        name="Transaction Name",
+        invoice_requires_successful_payment=False,
     )
 
 


### PR DESCRIPTION
### Context
The lago APi supports setting [`invoice-requires-successful-payment`](https://docs.getlago.com/api-reference/wallets/top-up#body-wallet-transaction-invoice-requires-successful-payment) during creation of Wallet or Wallet Transaction but this python library is missing these variables. 

This PR fixes that.



### Description

This pull request adds support for the new `invoice_requires_successful_payment` field to the wallet and wallet transaction models, their response models, and updates related tests to include this field. This change ensures that the client library can handle scenarios where invoices require successful payment for wallet operations.

**Model updates:**

* Added the `invoice_requires_successful_payment` field (as an optional boolean) to the `Wallet`, `WalletResponse`, `WalletTransaction`, and `WalletTransactionResponse` classes in `lago_python_client/models/wallet.py` and `lago_python_client/models/wallet_transaction.py` which is supported by lago API. [[1]](diffhunk://#diff-b8819b8db844d6618301adf5b1af2e5553218b2f0b0bd9f4e0c130aa6d5ec7d9R62) [[2]](diffhunk://#diff-b8819b8db844d6618301adf5b1af2e5553218b2f0b0bd9f4e0c130aa6d5ec7d9R87) [[3]](diffhunk://#diff-491055fc4f6429fe4df6f33fc7bee3438e8d10ae9458edbbe073dc2c30f947e6R13) [[4]](diffhunk://#diff-491055fc4f6429fe4df6f33fc7bee3438e8d10ae9458edbbe073dc2c30f947e6R32)

**Test updates:**

* Updated the `wallet_object` factory in `tests/test_wallet_client.py` and the `wallet_transaction_object` factory in `tests/test_wallet_transaction_client.py` to include the new `invoice_requires_successful_payment` field, ensuring tests validate the new functionality. [[1]](diffhunk://#diff-7f73f452da2b7785f597b5b684c3ada3f87cd48ae41c7fb0446624ee404bf049R38) [[2]](diffhunk://#diff-e10eb9d2e1a6b5acd6f0db0e23211270f3ee19416fa0a7ac5659f4778ee02637L13-R18)
