### PR TITLE
fix(models): Update `grouped_by` type to allow None in ProjectedGroupedUsage and GroupedUsage classes

### DIFF
--- a/lago_python_client/models/customer_projected_usage.py
+++ b/lago_python_client/models/customer_projected_usage.py
@@ -41,7 +41,7 @@ class ProjectedGroupedUsage(BaseModel):
     events_count: int
     units: str
     projected_units: str
-    grouped_by: Dict[str, str]
+    grouped_by: Dict[str, str | None]
     filters: List[ProjectedChargeFilterUsage]
     pricing_unit_details: Optional[PricingUnitDetails]
 

--- a/lago_python_client/models/customer_projected_usage.py
+++ b/lago_python_client/models/customer_projected_usage.py
@@ -41,7 +41,7 @@ class ProjectedGroupedUsage(BaseModel):
     events_count: int
     units: str
     projected_units: str
-    grouped_by: Dict[str, str | None]
+    grouped_by: Dict[str, Optional[str]]
     filters: List[ProjectedChargeFilterUsage]
     pricing_unit_details: Optional[PricingUnitDetails]
 

--- a/lago_python_client/models/customer_usage.py
+++ b/lago_python_client/models/customer_usage.py
@@ -37,7 +37,7 @@ class GroupedUsage(BaseModel):
     amount_cents: int
     events_count: int
     units: str
-    grouped_by: Dict[str, str | None]
+    grouped_by: Dict[str, Optional[str]]
     filters: List[ChargeFilterUsage]
     pricing_unit_details: Optional[PricingUnitDetails]
 

--- a/lago_python_client/models/customer_usage.py
+++ b/lago_python_client/models/customer_usage.py
@@ -37,7 +37,7 @@ class GroupedUsage(BaseModel):
     amount_cents: int
     events_count: int
     units: str
-    grouped_by: Dict[str, str]
+    grouped_by: Dict[str, str | None]
     filters: List[ChargeFilterUsage]
     pricing_unit_details: Optional[PricingUnitDetails]
 


### PR DESCRIPTION
This pull request updates the type annotations for the `grouped_by` field in two usage-related model classes to allow for `None` values in the dictionary values. This change ensures that the models can represent cases where some grouping keys may not have a value.

Model updates for grouping support:

* Updated the `grouped_by` field in the `GroupedUsage` class in `customer_usage.py` to use `Dict[str, str | None]`, allowing grouping values to be `None`.
* Updated the `grouped_by` field in the `ProjectedGroupedUsage` class in `customer_projected_usage.py` to use `Dict[str, str | None]`, allowing grouping values to be `None`.