### PR TITLE
feat(webhook): flexible webhook events

### DIFF
--- a/lago_python_client/models/webhook_endpoint.py
+++ b/lago_python_client/models/webhook_endpoint.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from lago_python_client.base_model import BaseModel
 
@@ -7,6 +7,9 @@ from ..base_model import BaseResponseModel
 
 class WebhookEndpoint(BaseModel):
     webhook_url: Optional[str]
+    signature_algo: Optional[str]
+    name: Optional[str]
+    event_types: Optional[List[str]]
 
 
 class WebhookEndpointResponse(BaseResponseModel):
@@ -14,4 +17,6 @@ class WebhookEndpointResponse(BaseResponseModel):
     lago_organization_id: str
     webhook_url: str
     signature_algo: Optional[str]
+    name: Optional[str]
+    event_types: Optional[List[str]]
     created_at: str

--- a/tests/fixtures/webhook_endpoint.json
+++ b/tests/fixtures/webhook_endpoint.json
@@ -4,6 +4,8 @@
     "lago_organization_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
     "webhook_url": "https://foo.bar",
     "signature_algo": "hmac",
+    "name": "My Webhook Endpoint",
+    "event_types": ["customer.created"],
     "created_at": "2022-04-29T08:59:51Z"
   }
 }

--- a/tests/fixtures/webhook_endpoint_index.json
+++ b/tests/fixtures/webhook_endpoint_index.json
@@ -4,12 +4,18 @@
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
       "lago_organization_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
       "webhook_url": "https://foo.bar",
+      "signature_algo": "hmac",
+      "name": null,
+      "event_types": null,
       "created_at": "2022-04-29T08:59:51Z"
     },
     {
       "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
       "lago_organization_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",
       "webhook_url": "https://foo.bar",
+      "signature_algo": "hmac",
+      "name": null,
+      "event_types": null,
       "created_at": "2022-04-29T08:59:51Z"
     }
   ],

--- a/tests/test_webhook_endpoint_client.py
+++ b/tests/test_webhook_endpoint_client.py
@@ -9,7 +9,12 @@ from lago_python_client.models import WebhookEndpoint
 
 
 def webhook_endpoint_object():
-    return WebhookEndpoint(webhook_url="https://foo.bar", signature_algo="hmac")
+    return WebhookEndpoint(
+        webhook_url="https://foo.bar",
+        signature_algo="hmac",
+        name="My Webhook Endpoint",
+        event_types=["customer.created"],
+    )
 
 
 def mock_response():


### PR DESCRIPTION
## Description

This PR introduces the ability for users to interact with two new attributes of the `WebhookEndpoint` resource: `event_types` and `name`.

See [lago-api PR#4981](https://github.com/getlago/lago-api/pull/4981) for additional details.
