### PR TITLE
Update AppliedInvoiceCustomSection to use nested InvoiceCustomSection

### DIFF
--- a/lago_python_client/models/invoice_custom_section.py
+++ b/lago_python_client/models/invoice_custom_section.py
@@ -10,16 +10,6 @@ class InvoiceCustomSectionInput(BaseModel):
     invoice_custom_section_codes: Optional[List[str]]
 
 
-class AppliedInvoiceCustomSection(BaseResponseModel):
-    lago_id: Optional[str]
-    invoice_custom_section_id: Optional[str]
-    created_at: Optional[str]
-
-
-class AppliedInvoiceCustomSections(BaseResponseModel):
-    __root__: List[AppliedInvoiceCustomSection]
-
-
 class InvoiceCustomSectionResponse(BaseResponseModel):
     lago_id: Optional[str]
     code: Optional[str]
@@ -28,6 +18,16 @@ class InvoiceCustomSectionResponse(BaseResponseModel):
     details: Optional[str]
     display_name: Optional[str]
     applied_to_organization: Optional[bool]  # Deprecated
+
+
+class AppliedInvoiceCustomSection(BaseResponseModel):
+    lago_id: Optional[str]
+    created_at: Optional[str]
+    invoice_custom_section: Optional[InvoiceCustomSectionResponse]
+
+
+class AppliedInvoiceCustomSections(BaseResponseModel):
+    __root__: List[AppliedInvoiceCustomSection]
 
 
 class InvoiceCustomSectionsResponseList(BaseResponseModel):

--- a/lago_python_client/models/invoice_custom_section.py
+++ b/lago_python_client/models/invoice_custom_section.py
@@ -22,6 +22,7 @@ class InvoiceCustomSectionResponse(BaseResponseModel):
 
 class AppliedInvoiceCustomSection(BaseResponseModel):
     lago_id: Optional[str]
+    invoice_custom_section_id: Optional[str]
     created_at: Optional[str]
     invoice_custom_section: Optional[InvoiceCustomSectionResponse]
 

--- a/tests/fixtures/subscription.json
+++ b/tests/fixtures/subscription.json
@@ -28,8 +28,12 @@
     "applied_invoice_custom_sections": [
       {
         "lago_id": "ics_12345",
-        "invoice_custom_section_id": "section_001",
-        "created_at": "2022-04-29T08:59:51Z"
+        "created_at": "2022-04-29T08:59:51Z",
+        "invoice_custom_section": {
+          "lago_id": "section_001",
+          "code": "section_code",
+          "name": "Section Name"
+        }
       }
     ]
   }

--- a/tests/fixtures/subscription.json
+++ b/tests/fixtures/subscription.json
@@ -28,6 +28,7 @@
     "applied_invoice_custom_sections": [
       {
         "lago_id": "ics_12345",
+        "invoice_custom_section_id": "section_001",
         "created_at": "2022-04-29T08:59:51Z",
         "invoice_custom_section": {
           "lago_id": "section_001",

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -35,8 +35,12 @@
         "applied_invoice_custom_sections": [
           {
             "lago_id": "ics_rule_001",
-            "invoice_custom_section_id": "section_rule_001",
-            "created_at": "2022-04-29T08:59:51Z"
+            "created_at": "2022-04-29T08:59:51Z",
+            "invoice_custom_section": {
+              "lago_id": "section_rule_001",
+              "code": "rule_section_code",
+              "name": "Rule Section Name"
+            }
           }
         ]
       }
@@ -62,8 +66,12 @@
     "applied_invoice_custom_sections": [
       {
         "lago_id": "ics_wallet_001",
-        "invoice_custom_section_id": "section_wallet_001",
-        "created_at": "2022-04-29T08:59:51Z"
+        "created_at": "2022-04-29T08:59:51Z",
+        "invoice_custom_section": {
+          "lago_id": "section_wallet_001",
+          "code": "wallet_section_code",
+          "name": "Wallet Section Name"
+        }
       }
     ]
   }

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -35,6 +35,7 @@
         "applied_invoice_custom_sections": [
           {
             "lago_id": "ics_rule_001",
+            "invoice_custom_section_id": "section_rule_001",
             "created_at": "2022-04-29T08:59:51Z",
             "invoice_custom_section": {
               "lago_id": "section_rule_001",
@@ -66,6 +67,7 @@
     "applied_invoice_custom_sections": [
       {
         "lago_id": "ics_wallet_001",
+        "invoice_custom_section_id": "section_wallet_001",
         "created_at": "2022-04-29T08:59:51Z",
         "invoice_custom_section": {
           "lago_id": "section_wallet_001",

--- a/tests/fixtures/wallet_transaction.json
+++ b/tests/fixtures/wallet_transaction.json
@@ -25,8 +25,12 @@
       "applied_invoice_custom_sections": [
         {
           "lago_id": "ics_tx_001",
-          "invoice_custom_section_id": "section_tx_001",
-          "created_at": "2022-04-29T08:59:51Z"
+          "created_at": "2022-04-29T08:59:51Z",
+          "invoice_custom_section": {
+            "lago_id": "section_tx_001",
+            "code": "tx_section_code",
+            "name": "TX Section Name"
+          }
         }
       ]
     },

--- a/tests/fixtures/wallet_transaction.json
+++ b/tests/fixtures/wallet_transaction.json
@@ -25,6 +25,7 @@
       "applied_invoice_custom_sections": [
         {
           "lago_id": "ics_tx_001",
+          "invoice_custom_section_id": "section_tx_001",
           "created_at": "2022-04-29T08:59:51Z",
           "invoice_custom_section": {
             "lago_id": "section_tx_001",

--- a/tests/test_customer_wallet_client.py
+++ b/tests/test_customer_wallet_client.py
@@ -255,7 +255,8 @@ def test_valid_create_customer_wallet_with_invoice_custom_section(httpx_mock: HT
 
     assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_wallet_001"
-    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.name == "Wallet Section Name"
     assert response.applied_invoice_custom_sections.__root__[0].created_at == "2022-04-29T08:59:51Z"
 
 
@@ -278,7 +279,7 @@ def test_valid_update_customer_wallet_with_invoice_custom_section(httpx_mock: HT
 
     assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_wallet_001"
-    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_wallet_001"
 
 
 def test_valid_create_customer_wallet_with_invoice_custom_section_on_recurring_transaction_rule(httpx_mock: HTTPXMock):
@@ -299,7 +300,7 @@ def test_valid_create_customer_wallet_with_invoice_custom_section_on_recurring_t
     assert (
         response.recurring_transaction_rules.__root__[0]
         .applied_invoice_custom_sections.__root__[0]
-        .invoice_custom_section_id
+        .invoice_custom_section.lago_id
         == "section_rule_001"
     )
 

--- a/tests/test_customer_wallet_client.py
+++ b/tests/test_customer_wallet_client.py
@@ -255,6 +255,7 @@ def test_valid_create_customer_wallet_with_invoice_custom_section(httpx_mock: HT
 
     assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_wallet_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_wallet_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.name == "Wallet Section Name"
     assert response.applied_invoice_custom_sections.__root__[0].created_at == "2022-04-29T08:59:51Z"
@@ -279,6 +280,7 @@ def test_valid_update_customer_wallet_with_invoice_custom_section(httpx_mock: HT
 
     assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_wallet_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_wallet_001"
 
 
@@ -296,6 +298,12 @@ def test_valid_create_customer_wallet_with_invoice_custom_section_on_recurring_t
     assert (
         response.recurring_transaction_rules.__root__[0].applied_invoice_custom_sections.__root__[0].lago_id
         == "ics_rule_001"
+    )
+    assert (
+        response.recurring_transaction_rules.__root__[0]
+        .applied_invoice_custom_sections.__root__[0]
+        .invoice_custom_section_id
+        == "section_rule_001"
     )
     assert (
         response.recurring_transaction_rules.__root__[0]
@@ -333,4 +341,10 @@ def test_valid_update_customer_wallet_with_invoice_custom_section_on_recurring_t
     assert (
         response.recurring_transaction_rules.__root__[0].applied_invoice_custom_sections.__root__[0].lago_id
         == "ics_rule_001"
+    )
+    assert (
+        response.recurring_transaction_rules.__root__[0]
+        .applied_invoice_custom_sections.__root__[0]
+        .invoice_custom_section_id
+        == "section_rule_001"
     )

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -1037,7 +1037,8 @@ def test_valid_create_subscription_with_invoice_custom_section(httpx_mock: HTTPX
 
     assert response.external_customer_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_12345"
-    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.name == "Section Name"
     assert response.applied_invoice_custom_sections.__root__[0].created_at == "2022-04-29T08:59:51Z"
 
 
@@ -1060,7 +1061,7 @@ def test_valid_update_subscription_with_invoice_custom_section(httpx_mock: HTTPX
 
     assert response.external_customer_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_12345"
-    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_001"
 
 
 # --- Default timeout tests ---

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -1037,6 +1037,7 @@ def test_valid_create_subscription_with_invoice_custom_section(httpx_mock: HTTPX
 
     assert response.external_customer_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_12345"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.name == "Section Name"
     assert response.applied_invoice_custom_sections.__root__[0].created_at == "2022-04-29T08:59:51Z"
@@ -1061,6 +1062,7 @@ def test_valid_update_subscription_with_invoice_custom_section(httpx_mock: HTTPX
 
     assert response.external_customer_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_12345"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_001"
 
 

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -501,7 +501,8 @@ def test_valid_create_wallet_with_invoice_custom_section(httpx_mock: HTTPXMock):
 
     assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_wallet_001"
-    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.name == "Wallet Section Name"
     assert response.applied_invoice_custom_sections.__root__[0].created_at == "2022-04-29T08:59:51Z"
 
 
@@ -524,7 +525,7 @@ def test_valid_update_wallet_with_invoice_custom_section(httpx_mock: HTTPXMock):
 
     assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_wallet_001"
-    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_wallet_001"
 
 
 def test_valid_create_wallet_with_invoice_custom_section_on_recurring_transaction_rule(httpx_mock: HTTPXMock):
@@ -545,7 +546,7 @@ def test_valid_create_wallet_with_invoice_custom_section_on_recurring_transactio
     assert (
         response.recurring_transaction_rules.__root__[0]
         .applied_invoice_custom_sections.__root__[0]
-        .invoice_custom_section_id
+        .invoice_custom_section.lago_id
         == "section_rule_001"
     )
 

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -501,6 +501,7 @@ def test_valid_create_wallet_with_invoice_custom_section(httpx_mock: HTTPXMock):
 
     assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_wallet_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_wallet_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.name == "Wallet Section Name"
     assert response.applied_invoice_custom_sections.__root__[0].created_at == "2022-04-29T08:59:51Z"
@@ -525,6 +526,7 @@ def test_valid_update_wallet_with_invoice_custom_section(httpx_mock: HTTPXMock):
 
     assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
     assert response.applied_invoice_custom_sections.__root__[0].lago_id == "ics_wallet_001"
+    assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section_id == "section_wallet_001"
     assert response.applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id == "section_wallet_001"
 
 
@@ -542,6 +544,12 @@ def test_valid_create_wallet_with_invoice_custom_section_on_recurring_transactio
     assert (
         response.recurring_transaction_rules.__root__[0].applied_invoice_custom_sections.__root__[0].lago_id
         == "ics_rule_001"
+    )
+    assert (
+        response.recurring_transaction_rules.__root__[0]
+        .applied_invoice_custom_sections.__root__[0]
+        .invoice_custom_section_id
+        == "section_rule_001"
     )
     assert (
         response.recurring_transaction_rules.__root__[0]
@@ -579,4 +587,10 @@ def test_valid_update_wallet_with_invoice_custom_section_on_recurring_transactio
     assert (
         response.recurring_transaction_rules.__root__[0].applied_invoice_custom_sections.__root__[0].lago_id
         == "ics_rule_001"
+    )
+    assert (
+        response.recurring_transaction_rules.__root__[0]
+        .applied_invoice_custom_sections.__root__[0]
+        .invoice_custom_section_id
+        == "section_rule_001"
     )

--- a/tests/test_wallet_transaction_client.py
+++ b/tests/test_wallet_transaction_client.py
@@ -240,7 +240,7 @@ def test_valid_create_wallet_transaction_with_invoice_custom_section(httpx_mock:
     assert response["wallet_transactions"][0].lago_id == "b7ab2926-1de8-4428-9bcd-779314ac1111"
     assert response["wallet_transactions"][0].applied_invoice_custom_sections.__root__[0].lago_id == "ics_tx_001"
     assert (
-        response["wallet_transactions"][0].applied_invoice_custom_sections.__root__[0].invoice_custom_section_id
+        response["wallet_transactions"][0].applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id
         == "section_tx_001"
     )
     assert (

--- a/tests/test_wallet_transaction_client.py
+++ b/tests/test_wallet_transaction_client.py
@@ -240,6 +240,10 @@ def test_valid_create_wallet_transaction_with_invoice_custom_section(httpx_mock:
     assert response["wallet_transactions"][0].lago_id == "b7ab2926-1de8-4428-9bcd-779314ac1111"
     assert response["wallet_transactions"][0].applied_invoice_custom_sections.__root__[0].lago_id == "ics_tx_001"
     assert (
+        response["wallet_transactions"][0].applied_invoice_custom_sections.__root__[0].invoice_custom_section_id
+        == "section_tx_001"
+    )
+    assert (
         response["wallet_transactions"][0].applied_invoice_custom_sections.__root__[0].invoice_custom_section.lago_id
         == "section_tx_001"
     )


### PR DESCRIPTION
 ## Summary                                                
  - Update `AppliedInvoiceCustomSection` model to replace flat `invoice_custom_section_id` field with a nested `InvoiceCustomSectionResponse` object containing `lago_id`, `code`, `name`, `description`, `details`, 
  and `display_name`                                                                                                                                                                                                
  - Update JSON test fixtures for subscription, wallet, wallet transaction to use the nested object format                                                                                                           
  - Update test assertions across subscription, wallet, customer wallet, and wallet transaction tests