### PR TITLE
fix(api): Deprecate filter_by prefixed params on current usage

### DIFF
--- a/lago_python_client/customers/clients.py
+++ b/lago_python_client/customers/clients.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from collections.abc import Mapping
 from typing import Any, ClassVar, Optional, Type, Union
 
@@ -47,15 +48,33 @@ class CustomerClient(
         filter_by_charge_code: Optional[str] = None,
         filter_by_group: Optional[dict] = None,
         full_usage: Optional[bool] = None,
+        charge_id: Optional[str] = None,
+        charge_code: Optional[str] = None,
+        billable_metric_code: Optional[str] = None,
+        group: Optional[dict] = None,
     ) -> CustomerUsageResponse:
         query_params: dict[str, Union[str, bool]] = {"external_subscription_id": external_subscription_id}
         if apply_taxes is not None:
             query_params["apply_taxes"] = apply_taxes
+        if charge_id is not None:
+            query_params["charge_id"] = charge_id
+        if charge_code is not None:
+            query_params["charge_code"] = charge_code
+        if billable_metric_code is not None:
+            query_params["billable_metric_code"] = billable_metric_code
+        if group is not None:
+            for k, v in group.items():
+                query_params[f"group[{k}]"] = v
         if filter_by_charge_id is not None:
+            warnings.warn("filter_by_charge_id is deprecated, use charge_id instead", DeprecationWarning, stacklevel=2)
             query_params["filter_by_charge_id"] = filter_by_charge_id
         if filter_by_charge_code is not None:
+            warnings.warn(
+                "filter_by_charge_code is deprecated, use charge_code instead", DeprecationWarning, stacklevel=2
+            )
             query_params["filter_by_charge_code"] = filter_by_charge_code
         if filter_by_group is not None:
+            warnings.warn("filter_by_group is deprecated, use group instead", DeprecationWarning, stacklevel=2)
             query_params["filter_by_group"] = json.dumps(filter_by_group)
         if full_usage is not None:
             query_params["full_usage"] = str(full_usage).lower()

--- a/tests/test_customer_client.py
+++ b/tests/test_customer_client.py
@@ -204,6 +204,36 @@ def test_valid_current_usage_with_filters(httpx_mock: HTTPXMock):
     assert len(response.charges_usage) == 1
 
 
+def test_valid_current_usage_with_new_filters(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+    charge_id = "1a901a90-1a90-1a90-1a90-1a901a901a90"
+
+    httpx_mock.add_response(
+        method="GET",
+        url=(
+            "https://api.getlago.com/api/v1/customers/external_customer_id/current_usage"
+            f"?external_subscription_id=123&charge_id={charge_id}"
+            "&charge_code=storage"
+            "&billable_metric_code=storage"
+            "&group%5Bcloud%5D=aws"
+            "&full_usage=true"
+        ),
+        content=mock_response("customer_usage"),
+    )
+    response = client.customers.current_usage(
+        "external_customer_id",
+        "123",
+        charge_id=charge_id,
+        charge_code="storage",
+        billable_metric_code="storage",
+        group={"cloud": "aws"},
+        full_usage=True,
+    )
+
+    assert response.from_datetime == "2022-07-01T00:00:00Z"
+    assert len(response.charges_usage) == 1
+
+
 def test_invalid_current_usage(httpx_mock: HTTPXMock):
     client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
 


### PR DESCRIPTION
## Context

We have different param naming convention in the `current_usage` endpoint. Some have the prefix `filter_by_`, not reflecting the pattern on the rest of the API. Add support for conventional ones, and mark the prefixed ones as deprecated.

## Description

Introduce unprefixed aliases for the `filter_by_*` query parameters on the `GET /customers/:customer_id/current_usage` endpoint (`charge_id, charge_code, billable_metric_code, group`), consistent with the naming convention used across the rest of the API.

The old `filter_by_*` names remain supported for backward compatibility.
