### PR TITLE
feat(clickhouse): Add organization.events_store attribute [ING-205]

### DIFF
--- a/lago_python_client/models/organization.py
+++ b/lago_python_client/models/organization.py
@@ -56,3 +56,4 @@ class OrganizationResponse(BaseResponseModel):
     email_settings: Optional[List[str]]
     finalize_zero_amount_invoice: Optional[bool]
     billing_configuration: Optional[OrganizationBillingConfiguration]
+    events_store: Optional[str]

--- a/tests/fixtures/organization.json
+++ b/tests/fixtures/organization.json
@@ -3,10 +3,7 @@
     "name": "Hooli",
     "created_at": "2022-05-02T13:04:09Z",
     "webhook_url": "https://test-example.example",
-    "webhook_urls": [
-      "https://test-example.example",
-      "https://test-example2.example"
-    ],
+    "webhook_urls": ["https://test-example.example", "https://test-example2.example"],
     "country": null,
     "default_currency": "USD",
     "address_line1": null,
@@ -28,6 +25,7 @@
       "invoice_grace_period": 3,
       "document_locale": "fr"
     },
+    "events_store": "clickhouse",
     "taxes": [
       {
         "lago_id": "b7ab2926-1de8-4428-9bcd-779314ac129b",


### PR DESCRIPTION
Related to https://github.com/getlago/lago-api/pull/5566

The PR documents the new `events_store` attribute on the organization object