### PR TITLE
[ING-30] test: Cover currency filter on list endpoints

### DIFF
--- a/tests/test_payment_request_client.py
+++ b/tests/test_payment_request_client.py
@@ -91,6 +91,20 @@ def test_valid_find_all_payment_requests_request_with_options(httpx_mock: HTTPXM
     assert response["meta"]["current_page"] == 1
 
 
+def test_valid_find_all_payment_requests_request_with_currency(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.getlago.com/api/v1/payment_requests?currency=EUR",
+        content=mock_collection_response(),
+    )
+    response = client.payment_requests.find_all({"currency": "EUR"})
+
+    assert response["payment_requests"][0].lago_id == "89b6b61e-4dbc-4307-ac96-4abcfa9e3e2d"
+    assert response["meta"]["current_page"] == 1
+
+
 def test_invalid_find_all_payment_requests_request(httpx_mock: HTTPXMock):
     client = Client(api_key="invalid")
 

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -328,6 +328,20 @@ def test_valid_find_all_subscription_request_with_options(httpx_mock: HTTPXMock)
     assert response["meta"]["current_page"] == 1
 
 
+def test_valid_find_all_subscription_request_with_currency(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.getlago.com/api/v1/subscriptions?currency=EUR",
+        content=mock_collection_response(),
+    )
+    response = client.subscriptions.find_all({"currency": "EUR"})
+
+    assert response["subscriptions"][0].lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
+    assert response["meta"]["current_page"] == 1
+
+
 def test_invalid_find_all_subscription_request(httpx_mock: HTTPXMock):
     client = Client(api_key="invalid")
 

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -407,6 +407,20 @@ def test_valid_find_all_wallet_request_with_options(httpx_mock: HTTPXMock):
     assert response["meta"]["current_page"] == 1
 
 
+def test_valid_find_all_wallet_request_with_currency(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.getlago.com/api/v1/wallets?currency=EUR",
+        content=mock_collection_response(),
+    )
+    response = client.wallets.find_all({"currency": "EUR"})
+
+    assert response["wallets"][0].lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
+    assert response["meta"]["current_page"] == 1
+
+
 def test_invalid_find_all_wallet_request(httpx_mock: HTTPXMock):
     client = Client(api_key="invalid")
 


### PR DESCRIPTION
## Context

The lago-api backend exposes an optional `currency` query parameter on the subscriptions, wallets, and payment_requests list endpoints (getlago/lago-api#5249). The Python client's `find_all(options)` already forwards arbitrary options as query parameters, so no source change is required, but the behavior was untested.

## Description

Adds a `find_all` test with `{"currency": "EUR"}` to the subscription, wallet, and payment_request client tests. Each registers an httpx mock keyed on the `currency` query string, so the test fails (pytest-httpx flags the unmatched request) if the option is not forwarded.

## How to try locally

```
python -m venv .venv && . .venv/bin/activate
pip install ".[test]"
python -m pytest tests/test_subscription_client.py tests/test_wallet_client.py tests/test_payment_request_client.py
```