### PR TITLE
[ING-239] feat(wallets): add grants_target_top_up to recurring transaction rules

### DIFF
--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -21,6 +21,7 @@ class RecurringTransactionRule(BaseModel):
     transaction_metadata: Optional[List[Dict[str, str]]]
     transaction_name: Optional[str]
     ignore_paid_top_up_limits: Optional[bool]
+    grants_target_top_up: Optional[bool]
     payment_method: Optional[PaymentMethod]
     invoice_custom_section: Optional[InvoiceCustomSectionInput]
 
@@ -41,6 +42,7 @@ class RecurringTransactionRuleResponse(BaseModel):
     transaction_metadata: Optional[List[Dict[str, str]]]
     transaction_name: Optional[str]
     ignore_paid_top_up_limits: Optional[bool]
+    grants_target_top_up: Optional[bool]
     payment_method: Optional[PaymentMethod]
     applied_invoice_custom_sections: Optional[AppliedInvoiceCustomSections]
 

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -28,6 +28,7 @@
         "target_ongoing_balance": "200.0",
         "transaction_name": "Recurring Transaction Rule",
         "ignore_paid_top_up_limits": true,
+        "grants_target_top_up": true,
         "payment_method": {
           "payment_method_type": "card",
           "payment_method_id": "pm_123"

--- a/tests/test_customer_wallet_client.py
+++ b/tests/test_customer_wallet_client.py
@@ -24,6 +24,7 @@ def wallet_object():
         target_ongoing_balance="105.0",
         transaction_name="Recurring Transaction Rule",
         ignore_paid_top_up_limits=True,
+        grants_target_top_up=True,
     )
     rules_list = RecurringTransactionRuleList(__root__=[rule])
     applies_to = AppliesTo(
@@ -73,6 +74,7 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
                         "target_ongoing_balance": "105.0",
                         "transaction_name": "Recurring Transaction Rule",
                         "ignore_paid_top_up_limits": True,
+                        "grants_target_top_up": True,
                     }
                 ],
                 "invoice_requires_successful_payment": False,
@@ -88,6 +90,7 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
     assert response.recurring_transaction_rules.__root__[0].trigger == "interval"
     assert response.recurring_transaction_rules.__root__[0].interval == "monthly"
     assert response.recurring_transaction_rules.__root__[0].ignore_paid_top_up_limits is True
+    assert response.recurring_transaction_rules.__root__[0].grants_target_top_up is True
     assert response.applies_to.fee_types[0] == "charge"
     assert response.applies_to.billable_metric_codes[0] == "usage"
     assert response.paid_top_up_max_amount_cents == 10000
@@ -348,3 +351,41 @@ def test_valid_update_customer_wallet_with_invoice_custom_section_on_recurring_t
         .invoice_custom_section_id
         == "section_rule_001"
     )
+
+
+def test_valid_update_wallet_with_grants_target_top_up_on_recurring_transaction_rule(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+    wallet_id = "b7ab2926-1de8-4428-9bcd-779314ac129b"
+    rule = RecurringTransactionRule(
+        trigger="interval",
+        interval="monthly",
+        method="target",
+        target_ongoing_balance="200.0",
+        grants_target_top_up=True,
+    )
+    rules_list = RecurringTransactionRuleList(__root__=[rule])
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://api.getlago.com/api/v1/customers/customer_id/wallets/" + wallet_id,
+        content=mock_response("wallet"),
+        match_json={
+            "wallet": {
+                "name": "name",
+                "recurring_transaction_rules": [
+                    {
+                        "interval": "monthly",
+                        "trigger": "interval",
+                        "method": "target",
+                        "target_ongoing_balance": "200.0",
+                        "grants_target_top_up": True,
+                    }
+                ],
+            }
+        },
+    )
+    wallet = Wallet(name="name", recurring_transaction_rules=rules_list)
+    response = client.customers.wallets.update("customer_id", wallet_id, wallet)
+
+    assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
+    assert response.recurring_transaction_rules.__root__[0].grants_target_top_up is True

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -25,6 +25,7 @@ def wallet_object():
         target_ongoing_balance="105.0",
         transaction_name="Recurring Transaction Rule",
         ignore_paid_top_up_limits=True,
+        grants_target_top_up=True,
     )
     rules_list = RecurringTransactionRuleList(__root__=[rule])
     applies_to = AppliesTo(
@@ -92,6 +93,7 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
                         "target_ongoing_balance": "105.0",
                         "transaction_name": "Recurring Transaction Rule",
                         "ignore_paid_top_up_limits": True,
+                        "grants_target_top_up": True,
                     }
                 ],
                 "invoice_requires_successful_payment": False,
@@ -107,6 +109,7 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
     assert response.recurring_transaction_rules.__root__[0].trigger == "interval"
     assert response.recurring_transaction_rules.__root__[0].interval == "monthly"
     assert response.recurring_transaction_rules.__root__[0].ignore_paid_top_up_limits is True
+    assert response.recurring_transaction_rules.__root__[0].grants_target_top_up is True
     assert response.applies_to.fee_types[0] == "charge"
     assert response.applies_to.billable_metric_codes[0] == "usage"
     assert response.paid_top_up_max_amount_cents == 10000
@@ -594,3 +597,41 @@ def test_valid_update_wallet_with_invoice_custom_section_on_recurring_transactio
         .invoice_custom_section_id
         == "section_rule_001"
     )
+
+
+def test_valid_update_wallet_with_grants_target_top_up_on_recurring_transaction_rule(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+    wallet_id = "b7ab2926-1de8-4428-9bcd-779314ac129b"
+    rule = RecurringTransactionRule(
+        trigger="interval",
+        interval="monthly",
+        method="target",
+        target_ongoing_balance="200.0",
+        grants_target_top_up=True,
+    )
+    rules_list = RecurringTransactionRuleList(__root__=[rule])
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://api.getlago.com/api/v1/wallets/" + wallet_id,
+        content=mock_response(),
+        match_json={
+            "wallet": {
+                "name": "name",
+                "recurring_transaction_rules": [
+                    {
+                        "interval": "monthly",
+                        "trigger": "interval",
+                        "method": "target",
+                        "target_ongoing_balance": "200.0",
+                        "grants_target_top_up": True,
+                    }
+                ],
+            }
+        },
+    )
+    wallet = Wallet(name="name", recurring_transaction_rules=rules_list)
+    response = client.wallets.update(wallet, wallet_id)
+
+    assert response.lago_id == "b7ab2926-1de8-4428-9bcd-779314ac129b"
+    assert response.recurring_transaction_rules.__root__[0].grants_target_top_up is True


### PR DESCRIPTION
## Context

Wallet recurring transaction rules of type `target` previously always created a paid top-up; there was no way to grant free credits through a target rule. The API now supports this via a nullable boolean `grants_target_top_up` on the recurring transaction rule (getlago/lago-api#5755). On a `target` rule, `true` makes the periodic gap-fill grant free credits to reach the target balance instead of creating a paid top-up; `false`, the default for target rules, keeps the current paid behaviour. The field is `null` for `fixed` rules.

## Description

Exposes `grants_target_top_up` in the SDK so consumers can set it on create/update and read it from responses:

- Adds `grants_target_top_up: Optional[bool]` to both `RecurringTransactionRule` (input) and `RecurringTransactionRuleResponse`.
- Adds create and update coverage (customer-scoped and top-level) asserting the field is forwarded in the request body and parsed from the response.

No version bump: released separately, per repo convention.

## How to try locally

```
python3 -m pytest tests/test_wallet_client.py tests/test_customer_wallet_client.py
```

