### PR TITLE
feat(multi-entity): expose billing_entity_code on subscription, walle…

### DIFF
--- a/lago_python_client/models/credit_note.py
+++ b/lago_python_client/models/credit_note.py
@@ -39,6 +39,7 @@ class CreditNoteAppliedTaxes(BaseResponseModel):
 class CreditNoteResponse(BaseResponseModel):
     lago_id: Optional[str]
     sequential_id: Optional[int]
+    billing_entity_code: Optional[str]
     number: Optional[str]
     lago_invoice_id: Optional[str]
     invoice_number: Optional[str]

--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -57,6 +57,7 @@ class OneOffInvoice(BaseModel):
     error_details: Optional[ErrorDetailsResponse]
     payment_method: Optional[PaymentMethod]
     invoice_custom_section: Optional[InvoiceCustomSectionInput]
+    billing_entity_code: Optional[str]
 
 
 class InvoicePreview(BaseModel):
@@ -66,6 +67,7 @@ class InvoicePreview(BaseModel):
     coupons: Optional[CouponsList]
     customer: Optional[Customer]
     subscriptions: Optional[Subscriptions]
+    billing_entity_code: Optional[str]
 
 
 class InvoiceAppliedTax(BaseResponseModel):

--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -20,6 +20,7 @@ class Subscription(BaseModel):
     payment_method: Optional[PaymentMethod]
     invoice_custom_section: Optional[InvoiceCustomSectionInput]
     consolidate_invoice: Optional[bool]
+    billing_entity_code: Optional[str]
 
 
 class Subscriptions(BaseModel):
@@ -57,6 +58,7 @@ class SubscriptionResponse(BaseResponseModel):
     payment_method: Optional[PaymentMethod]
     applied_invoice_custom_sections: Optional[AppliedInvoiceCustomSections]
     consolidate_invoice: Optional[bool]
+    billing_entity_code: Optional[str]
 
 
 class SubscriptionsResponse(BaseResponseModel):

--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -79,6 +79,7 @@ class Wallet(BaseModel):
     metadata: Optional[Dict[str, Optional[str]]]
     payment_method: Optional[PaymentMethod]
     invoice_custom_section: Optional[InvoiceCustomSectionInput]
+    billing_entity_code: Optional[str]
 
 
 class WalletResponse(BaseResponseModel):
@@ -111,3 +112,4 @@ class WalletResponse(BaseResponseModel):
     metadata: Optional[Dict[str, Optional[str]]]
     payment_method: Optional[PaymentMethod]
     applied_invoice_custom_sections: Optional[AppliedInvoiceCustomSections]
+    billing_entity_code: Optional[str]


### PR DESCRIPTION
## Summary

Multi-entity additions to the Python client: callers can now pin a subscription, wallet, or one-off invoice to a specific billing entity at create/update time, and read the resolved entity back from subscription, wallet, invoice, and credit-note responses.

## Changes

- `Subscription.billing_entity_code` — sent on `POST /subscriptions` and `PUT /subscriptions/:external_id`.
- `SubscriptionResponse.billing_entity_code` — read back on every subscription response.
- `Wallet.billing_entity_code` — sent on `POST /wallets` and `POST /customers/:external_id/wallets`.
- `WalletResponse.billing_entity_code` — read back on every wallet response.
- `OneOffInvoice.billing_entity_code` — sent on `POST /invoices` (one-off).
- `InvoicePreview.billing_entity_code` — sent on `POST /invoices/preview`.
- `CreditNoteResponse.billing_entity_code` — read back on every credit-note response (`InvoiceResponse` already had it).

## Notes

No list-endpoint changes were needed. The `FindAllCommandMixin` already takes a generic `options: QueryPairs` dict, and `QueryPairs` in `services/request.py` is typed as `Mapping[str, Union[int, str, list[str]]]` — so callers can already pass `client.subscriptions.find_all(options={"billing_entity_codes[]": ["EU", "US"]})` against `GET /subscriptions`, `GET /wallets`, and `GET /payment_requests` without any client refactor.

## Test plan

- [x] `pytest tests/` — 411 passed
- [x] Smoke-checked that `billing_entity_code` lands in `__fields__` for `Subscription`, `SubscriptionResponse`, `Wallet`, `WalletResponse`, `OneOffInvoice`, `InvoicePreview`, `CreditNoteResponse`.
- [ ] (Not added in this PR) Fixture/assertion coverage for the new fields on the response side and for the request-body serialization. Existing tests don't break because their fixtures and expected payloads don't reference `billing_entity_code`, but a follow-up should add `"billing_entity_code": "..."` to `subscription.json`, `wallet.json`, `credit_note.json` and corresponding assertions.
