### PR TITLE
feat(purchase-order): add purchase_order_number models

### DIFF
--- a/lago_python_client/models/subscription.py
+++ b/lago_python_client/models/subscription.py
@@ -26,6 +26,7 @@ class Subscription(BaseModel):
     invoice_custom_section: Optional[InvoiceCustomSectionInput]
     consolidate_invoice: Optional[bool]
     billing_entity_code: Optional[str]
+    purchase_order_number: Optional[str]
     activation_rules: Optional[List[ActivationRuleInput]]
 
 
@@ -75,6 +76,7 @@ class SubscriptionResponse(BaseResponseModel):
     applied_invoice_custom_sections: Optional[AppliedInvoiceCustomSections]
     consolidate_invoice: Optional[bool]
     billing_entity_code: Optional[str]
+    purchase_order_number: Optional[str]
     cancellation_reason: Optional[str]
     activated_at: Optional[str]
     activation_rules: Optional[List[ActivationRuleResponse]]

--- a/lago_python_client/models/wallet.py
+++ b/lago_python_client/models/wallet.py
@@ -22,6 +22,7 @@ class RecurringTransactionRule(BaseModel):
     transaction_name: Optional[str]
     ignore_paid_top_up_limits: Optional[bool]
     grants_target_top_up: Optional[bool]
+    purchase_order_number: Optional[str]
     payment_method: Optional[PaymentMethod]
     invoice_custom_section: Optional[InvoiceCustomSectionInput]
 
@@ -43,6 +44,7 @@ class RecurringTransactionRuleResponse(BaseModel):
     transaction_name: Optional[str]
     ignore_paid_top_up_limits: Optional[bool]
     grants_target_top_up: Optional[bool]
+    purchase_order_number: Optional[str]
     payment_method: Optional[PaymentMethod]
     applied_invoice_custom_sections: Optional[AppliedInvoiceCustomSections]
 
@@ -82,6 +84,7 @@ class Wallet(BaseModel):
     payment_method: Optional[PaymentMethod]
     invoice_custom_section: Optional[InvoiceCustomSectionInput]
     billing_entity_code: Optional[str]
+    purchase_order_number: Optional[str]
 
 
 class WalletResponse(BaseResponseModel):
@@ -115,3 +118,4 @@ class WalletResponse(BaseResponseModel):
     payment_method: Optional[PaymentMethod]
     applied_invoice_custom_sections: Optional[AppliedInvoiceCustomSections]
     billing_entity_code: Optional[str]
+    purchase_order_number: Optional[str]

--- a/lago_python_client/models/wallet_transaction.py
+++ b/lago_python_client/models/wallet_transaction.py
@@ -16,6 +16,7 @@ class WalletTransaction(BaseModel):
     metadata: Optional[List[Dict[str, str]]]
     name: Optional[str]
     ignore_paid_top_up_limits: Optional[bool]
+    purchase_order_number: Optional[str]
     payment_method: Optional[PaymentMethod]
     invoice_custom_section: Optional[InvoiceCustomSectionInput]
 
@@ -41,6 +42,7 @@ class WalletTransactionResponse(BaseResponseModel):
     metadata: Optional[List[Dict[str, str]]]
     name: Optional[str]
     invoice_requires_successful_payment: Optional[bool]
+    purchase_order_number: Optional[str]
     payment_method: Optional[PaymentMethod]
     applied_invoice_custom_sections: Optional[AppliedInvoiceCustomSections]
 

--- a/tests/fixtures/subscription.json
+++ b/tests/fixtures/subscription.json
@@ -16,6 +16,7 @@
     "on_termination_credit_note": "skip",
     "on_termination_invoice": "skip",
     "consolidate_invoice": false,
+    "purchase_order_number": "PO-123",
     "subscription_at": "2022-04-29T08:59:51Z",
     "previous_plan_code": null,
     "next_plan_code": null,

--- a/tests/fixtures/wallet.json
+++ b/tests/fixtures/wallet.json
@@ -27,6 +27,7 @@
         "started_at": null,
         "target_ongoing_balance": "200.0",
         "transaction_name": "Recurring Transaction Rule",
+        "purchase_order_number": "PO-RULE-123",
         "ignore_paid_top_up_limits": true,
         "grants_target_top_up": true,
         "payment_method": {
@@ -53,6 +54,7 @@
     "credits_ongoing_usage_balance": "2.0",
     "paid_top_up_max_amount_cents": 10000,
     "paid_top_up_min_amount_cents": 500,
+    "purchase_order_number": "PO-123",
     "applies_to": {
       "fee_types": ["charge"],
       "billable_metric_codes": ["usage"]

--- a/tests/fixtures/wallet_transaction.json
+++ b/tests/fixtures/wallet_transaction.json
@@ -18,6 +18,7 @@
       "settled_at": "2022-04-29T08:59:51Z",
       "created_at": "2022-04-29T08:59:51Z",
       "name": "Transaction Name",
+      "purchase_order_number": "PO-123",
       "payment_method": {
         "payment_method_type": "card",
         "payment_method_id": "pm_123"

--- a/tests/test_subscription_client.py
+++ b/tests/test_subscription_client.py
@@ -88,6 +88,7 @@ def test_valid_create_subscriptions_request(httpx_mock: HTTPXMock):
     assert response.subscription_at == "2022-04-29T08:59:51Z"
     assert response.ending_at == "2022-08-29T08:59:51Z"
     assert response.consolidate_invoice is False
+    assert response.purchase_order_number == "PO-123"
 
 
 def test_valid_create_subscriptions_request_with_payment_method(httpx_mock: HTTPXMock):

--- a/tests/test_wallet_client.py
+++ b/tests/test_wallet_client.py
@@ -24,6 +24,7 @@ def wallet_object():
         method="target",
         target_ongoing_balance="105.0",
         transaction_name="Recurring Transaction Rule",
+        purchase_order_number="PO-RULE-123",
         ignore_paid_top_up_limits=True,
         grants_target_top_up=True,
     )
@@ -46,6 +47,7 @@ def wallet_object():
         transaction_name="Transaction Name",
         paid_top_up_max_amount_cents=10000,
         paid_top_up_min_amount_cents=500,
+        purchase_order_number="PO-123",
     )
 
 
@@ -92,12 +94,14 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
                         "granted_credits": "105.0",
                         "target_ongoing_balance": "105.0",
                         "transaction_name": "Recurring Transaction Rule",
+                        "purchase_order_number": "PO-RULE-123",
                         "ignore_paid_top_up_limits": True,
                         "grants_target_top_up": True,
                     }
                 ],
                 "invoice_requires_successful_payment": False,
                 "transaction_name": "Transaction Name",
+                "purchase_order_number": "PO-123",
                 "applies_to": {"fee_types": ["charge"], "billable_metric_codes": ["usage"]},
             }
         },
@@ -114,6 +118,8 @@ def test_valid_create_wallet_request(httpx_mock: HTTPXMock):
     assert response.applies_to.billable_metric_codes[0] == "usage"
     assert response.paid_top_up_max_amount_cents == 10000
     assert response.paid_top_up_min_amount_cents == 500
+    assert response.purchase_order_number == "PO-123"
+    assert response.recurring_transaction_rules.__root__[0].purchase_order_number == "PO-RULE-123"
 
 
 def test_valid_create_wallet_request_with_payment_method_on_wallet(httpx_mock: HTTPXMock):

--- a/tests/test_wallet_transaction_client.py
+++ b/tests/test_wallet_transaction_client.py
@@ -15,6 +15,7 @@ def wallet_transaction_object():
         granted_credits="10",
         voided_credits="0",
         name="Transaction Name",
+        purchase_order_number="PO-123",
         invoice_requires_successful_payment=False,
     )
 
@@ -74,6 +75,7 @@ def test_valid_create_wallet_transaction_request(httpx_mock: HTTPXMock):
     assert response["wallet_transactions"][1].lago_credit_note_id == "credit-note-uuid-2222"
     assert response["wallet_transactions"][2].lago_credit_note_id is None
     assert response["wallet_transactions"][0].priority == 50
+    assert response["wallet_transactions"][0].purchase_order_number == "PO-123"
     assert response["wallet_transactions"][1].priority == 50
     assert response["wallet_transactions"][2].priority == 50
 


### PR DESCRIPTION
This commit introduces the purchase order number

- Subscriptions
- Wallets and Wallets Transactions