### PR TITLE
feat(invoices): add deleting a draft invoice

### DIFF
--- a/lago_python_client/invoices/clients.py
+++ b/lago_python_client/invoices/clients.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, Mapping, Optional, Type
 from ..base_client import BaseClient
 from ..mixins import (
     CreateCommandMixin,
+    DestroyCommandMixin,
     FindAllCommandMixin,
     FindCommandMixin,
     UpdateCommandMixin,
@@ -24,6 +25,7 @@ class InvoiceClient(
     FindAllCommandMixin[InvoiceResponse],
     UpdateCommandMixin[InvoiceResponse],
     CreateCommandMixin[InvoiceResponse],
+    DestroyCommandMixin[InvoiceResponse],
     BaseClient,
 ):
     API_RESOURCE: ClassVar[str] = "invoices"

--- a/tests/test_invoice_client.py
+++ b/tests/test_invoice_client.py
@@ -307,6 +307,32 @@ def test_valid_void_invoice_request(httpx_mock: HTTPXMock):
     assert response.lago_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
 
 
+def test_valid_destroy_invoice_request(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url="https://api.getlago.com/api/v1/invoices/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        content=mock_response(),
+    )
+    response = client.invoices.destroy("5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba")
+
+    assert response.lago_id == "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba"
+
+
+def test_invalid_destroy_invoice_request(httpx_mock: HTTPXMock):
+    client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url="https://api.getlago.com/api/v1/invoices/5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        status_code=422,
+        content=b"",
+    )
+    with pytest.raises(LagoApiError):
+        client.invoices.destroy("5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba")
+
+
 def test_valid_retry_payment_invoice_request(httpx_mock: HTTPXMock):
     client = Client(api_key="886fe239-927d-4072-ab72-6dd345e8dd0d")
 


### PR DESCRIPTION
## Context

_Part of the "delete draft invoice" feature_

A new endpoint was added to delete a draft invoice (https://github.com/getlago/lago-api/pull/5968).

## Description

Adds support for deleting a draft invoice (`DELETE /invoices/:id`).

`InvoiceClient` now includes `DestroyCommandMixin`, so you can call `client.invoices.destroy(invoice_id)`.