### PR TITLE
feat(invoice): add web_url to invoice response models

### DIFF
--- a/lago_python_client/models/invoice.py
+++ b/lago_python_client/models/invoice.py
@@ -139,6 +139,7 @@ class InvoiceResponse(BaseResponseModel):
     prepaid_purchased_credit_amount_cents: Optional[int]
 
     file_url: Optional[str]
+    web_url: Optional[str]
     customer: Optional[CustomerResponse]
     billing_periods: Optional[BillingPeriodsResponse]
     subscriptions: Optional[SubscriptionsResponse]

--- a/lago_python_client/models/payment_request.py
+++ b/lago_python_client/models/payment_request.py
@@ -33,6 +33,7 @@ class PaymentRequestInvoiceResponse(BaseResponseModel):
     total_amount_cents: int
     prepaid_credit_amount_cents: int
     file_url: Optional[str]
+    web_url: Optional[str]
 
 
 class PaymentRequestInvoicesResponse(BaseResponseModel):


### PR DESCRIPTION
## Context

The invoice API object exposes a web_url attribute linking to the invoice page in the Lago dashboard, next to file_url (the PDF).

## Description

Add web_url as an optional string on InvoiceResponse and on PaymentRequestInvoiceResponse, which mirrors the same invoice base object. Without it pydantic silently drops the field from the parsed response.
