### PR TITLE
fix: authenticate child resource listings

### DIFF
--- a/lago_python_client/mixins.py
+++ b/lago_python_client/mixins.py
@@ -173,6 +173,7 @@ class FindAllChildrenCommandMixin(Generic[_M]):
                 ),
                 query_pairs=options,
             ),
+            headers=make_headers(api_key=self.api_key),
             rate_limit_retry_config=self.rate_limit_retry_config,
         )
 

--- a/tests/test_find_all_children.py
+++ b/tests/test_find_all_children.py
@@ -1,0 +1,40 @@
+import pytest
+from pytest_httpx import HTTPXMock
+
+from lago_python_client.client import Client
+
+
+@pytest.mark.parametrize(
+    "client_name,parent_resource,child_resource",
+    [
+        ("customer_applied_coupons", "customers", "applied_coupons"),
+        ("customer_credit_notes", "customers", "credit_notes"),
+        ("customer_invoices", "customers", "invoices"),
+        ("customer_payment_methods", "customers", "payment_methods"),
+        ("customer_payment_requests", "customers", "payment_requests"),
+        ("customer_payments", "customers", "payments"),
+        ("customer_subscriptions", "customers", "subscriptions"),
+        ("customer_wallets", "customers", "wallets"),
+        ("plan_charges", "plans", "charges"),
+        ("plan_fixed_charges", "plans", "fixed_charges"),
+        ("subscription_charges", "subscriptions", "charges"),
+        ("subscription_fixed_charges", "subscriptions", "fixed_charges"),
+    ],
+)
+def test_find_all_children_sends_authentication_headers(
+    httpx_mock: HTTPXMock, client_name: str, parent_resource: str, child_resource: str
+):
+    client = Client(api_key="test-api-key")
+    response_data = {child_resource: [], "meta": {"current_page": 1}}
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://api.getlago.com/api/v1/{parent_resource}/parent-id/{child_resource}?per_page=2&page=1",
+        json=response_data,
+    )
+
+    response = getattr(client, client_name).find_all(resource_id="parent-id", options={"per_page": 2, "page": 1})
+
+    request = httpx_mock.get_request()
+    assert request.headers["Authorization"] == "Bearer test-api-key"
+    assert request.headers["Content-Type"] == "application/json"
+    assert response == response_data


### PR DESCRIPTION
Child-resource listing requests now send the configured API key, preventing missing-header 401 failures across all twelve inherited `find_all` methods. The regression test exercises each public entry point with pagination and checks the outgoing headers and returned metadata.

Credit to telesoho for the original authentication fix. This PR keeps the existing `timetour` parameter and timeout behavior; changing those needs a separate compatibility decision.

Related: #410, #385.

Validation: all 12 new cases fail before the fix; `python -m pytest tests` passes all 461 tests after it. Repository-wide Ruff lint and formatting checks also pass. Tested on Windows with Python 3.12.9 and HTTPX 0.28.1; HTTP requests are mocked.

AI-assisted implementation and local verification.
